### PR TITLE
Remove unnecessary configuration options

### DIFF
--- a/docs/compatibility/postgres.js.md
+++ b/docs/compatibility/postgres.js.md
@@ -29,10 +29,8 @@ Second, add the following rule to your ESLint config:
       {
         "connections": [
           {
-            // The migrations path:
-            "migrationsDir": "./your_migrations_folder_path",
-            // A shadow database name (see explanation in Configuration):
-            "databaseName": "my_db_shadow",
+            // ...
+
             // The name of the variable that holds the connection:
             "tagName": "sql",
             // Postgre.js type should be an array, so we add an extra "[]" after the generated type:

--- a/docs/compatibility/sequelize.md
+++ b/docs/compatibility/sequelize.md
@@ -37,10 +37,8 @@ Second, add the following rule to your ESLint config:
       {
         "connections": [
           {
-            // The migrations path:
-            "migrationsDir": "./your_migrations_folder_path",
-            // A shadow database name (see explanation in Configuration):
-            "databaseName": "my_db_shadow",
+            // ...
+
             // The name of the variable that holds the connection:
             "name": "sequelize",
             // An array of operators that wraps the raw query:


### PR DESCRIPTION
The configuration options on this page are confusing because they imply that Postgres.js and Sequelize can only be used with migrations instead of the simpler `databaseUrl` configuration.