### PR TITLE
Update postgres version to 3.3.0

### DIFF
--- a/demos/basic-migrations-raw/package.json
+++ b/demos/basic-migrations-raw/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@ts-safeql-demos/shared": "workspace:*",
     "@ts-safeql/eslint-plugin": "workspace:*",
-    "postgres": "github:porsager/postgres"
+    "postgres": "^3.3.0"
   }
 }

--- a/demos/basic-transform-type/package.json
+++ b/demos/basic-transform-type/package.json
@@ -20,6 +20,6 @@
     "@ts-safeql-demos/shared": "workspace:*",
     "@ts-safeql/eslint-plugin": "workspace:*",
     "@types/node": "^18.7.16",
-    "postgres": "github:porsager/postgres"
+    "postgres": "^3.3.0"
   }
 }

--- a/demos/basic/package.json
+++ b/demos/basic/package.json
@@ -20,6 +20,6 @@
     "@ts-safeql-demos/shared": "workspace:*",
     "@ts-safeql/eslint-plugin": "workspace:*",
     "@types/node": "^18.7.16",
-    "postgres": "github:porsager/postgres"
+    "postgres": "^3.3.0"
   }
 }

--- a/demos/multi-connections/package.json
+++ b/demos/multi-connections/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@ts-safeql-demos/shared": "workspace:*",
     "@ts-safeql/eslint-plugin": "workspace:*",
-    "postgres": "github:porsager/postgres"
+    "postgres": "^3.3.0"
   }
 }

--- a/demos/postgresjs-demo/package.json
+++ b/demos/postgresjs-demo/package.json
@@ -20,6 +20,6 @@
     "@ts-safeql-demos/shared": "workspace:*",
     "@ts-safeql/eslint-plugin": "workspace:*",
     "@types/node": "^18.7.16",
-    "postgres": "github:porsager/postgres"
+    "postgres": "^3.3.0"
   }
 }

--- a/demos/shared/package.json
+++ b/demos/shared/package.json
@@ -6,6 +6,6 @@
   },
   "dependencies": {
     "@types/node": "^18.7.16",
-    "postgres": "github:porsager/postgres"
+    "postgres": "^3.3.0"
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/utils": "^5.36.2",
     "fp-ts": "^2.12.3",
     "pg-connection-string": "2.5.0",
-    "postgres": "github:porsager/postgres",
+    "postgres": "^3.3.0",
     "recast": "^0.21.2",
     "source-map-support": "^0.5.21",
     "synckit": "^0.8.4",

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -35,7 +35,7 @@
     "@ts-safeql/test-utils": "workspace:0.0.1",
     "fp-ts": "^2.12.3",
     "pg-connection-string": "^2.5.0",
-    "postgres": "github:porsager/postgres",
+    "postgres": "^3.3.0",
     "source-map-support": "^0.5.21"
   }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -28,6 +28,6 @@
     "@ts-safeql/shared": "workspace:0.0.1",
     "nanoid": "^4.0.0",
     "pg-connection-string": "^2.5.0",
-    "postgres": "github:porsager/postgres"
+    "postgres": "^3.3.0"
   }
 }


### PR DESCRIPTION
Now that [Postgres.js was published as v3.3.0](https://github.com/ts-safeql/safeql/issues/56#issuecomment-1263989878), the GitHub version can be changed to a normal semver specifier.