### PR TITLE
Type fix

### DIFF
--- a/docs/compatibility/prisma.md
+++ b/docs/compatibility/prisma.md
@@ -73,7 +73,7 @@ const query = prisma.$queryRaw(
 
 // After: ✅
 const query = prisma.$queryRaw<{ id: number; }[]>(
-  Prisma.sql`SELECT idd FROM users`
+  Prisma.sql`SELECT id FROM users`
 )
 ```
 


### PR DESCRIPTION
The “After Query Sample” was misspelled
 changes :
idd into id to match the type annotation.