### PR TITLE
Allow for newer major libpg-query versions

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -46,6 +46,6 @@
     "zod-to-json-schema": "^3.20.1"
   },
   "peerDependencies": {
-    "libpg-query": "^13.2.5"
+    "libpg-query": ">=13.2.5"
   }
 }


### PR DESCRIPTION
Hi @Newbie012, happy new year! 🎉 Hope you are well.

Quick PR to allow for newer major `libpg-query` versions such as `14.x.x` and `15.x.x`