### PR TITLE
feat: add nullAsUndefined and nullAsOptional connection options

### DIFF
--- a/.changeset/neat-lamps-sniff.md
+++ b/.changeset/neat-lamps-sniff.md
@@ -1,0 +1,7 @@
+---
+"@ts-safeql/eslint-plugin": patch
+"@ts-safeql/generate": patch
+"@ts-safeql-demos/postgresjs-custom-types": patch
+---
+
+feat: add `nullAsUndefined` and `nullAsOptional` connection options

--- a/demos/postgresjs-custom-types/.eslintrc.json
+++ b/demos/postgresjs-custom-types/.eslintrc.json
@@ -13,9 +13,14 @@
           "targets": [{ "tag": "sql", "transform": "{type}[]" }],
           "overrides": {
             "types": {
-              "timestamptz": { "parameter": "+(Parameter<LocalDate>|LocalDate)", "return": "LocalDate" }
+              "timestamptz": {
+                "parameter": "+(Parameter<LocalDate>|LocalDate)",
+                "return": "LocalDate"
+              }
             }
-          }
+          },
+          "nullAsUndefined": true,
+          "nullAsOptional": true
         }
       }
     ]

--- a/demos/postgresjs-custom-types/src/index.ts
+++ b/demos/postgresjs-custom-types/src/index.ts
@@ -16,10 +16,16 @@ const sql = postgres({
       serialize: (value: LocalDateTime) => value.toString(),
     },
   },
+  transform: {
+    // JS -> Postgres - Convert undefined to null
+    undefined: null,
+    // Postgres -> JS - Convert null to undefined
+    value: (value) => value ?? undefined,
+  },
 });
 
 async function check() {
-  const value = await sql<{ x: LocalDate | null }[]>`SELECT ${LocalDate.now()} as x`;
+  const value = await sql<{ x?: LocalDate | undefined }[]>`SELECT ${LocalDate.now()} as x`;
 
   await sql.end();
 

--- a/packages/eslint-plugin/src/rules/check-sql.rule.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.rule.ts
@@ -124,6 +124,16 @@ const zBaseSchema = z.object({
     })
     .partial()
     .optional(),
+
+  /**
+   * Use `undefined` instead of `null` when the value is nullable.
+   */
+  nullAsUndefined: z.boolean().optional(),
+
+  /**
+   * Mark the property as optional when the value is nullable.
+   */
+  nullAsOptional: z.boolean().optional(),
 });
 
 export const zConnectionMigration = z.object({

--- a/packages/eslint-plugin/src/rules/check-sql.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.test.ts
@@ -1126,6 +1126,77 @@ RuleTester.describe("check-sql", () => {
     ],
   });
 
+  ruleTester.run("connection with null options", rules["check-sql"], {
+    valid: [
+      {
+        name: "use undefined instead of null",
+        filename,
+        options: withConnection(connections.withTag, {
+          nullAsUndefined: true,
+        }),
+        code: "sql<{ middle_name: string | undefined }>`select middle_name from caregiver`",
+      },
+      {
+        name: "mark nullable field as optional",
+        filename,
+        options: withConnection(connections.withTag, {
+          nullAsUndefined: true,
+          nullAsOptional: true,
+        }),
+        code: "sql<{ middle_name?: string | undefined }>`select middle_name from caregiver`",
+      },
+    ],
+    invalid: [
+      {
+        name: "without nullAsUndefined while result is undefined",
+        filename,
+        options: withConnection(connections.withTag),
+        code: "sql<{ middle_name: string | undefined }>`select middle_name from caregiver`",
+        output: "sql<{ middle_name: string | null; }>`select middle_name from caregiver`",
+        errors: [
+          { messageId: "incorrectTypeAnnotations", line: 1, column: 5, endLine: 1, endColumn: 40 },
+        ],
+      },
+      {
+        name: "with nullAsUndefined while result is null",
+        filename,
+        options: withConnection(connections.withTag, {
+          nullAsUndefined: true,
+        }),
+        code: "sql<{ middle_name: string | null }>`select middle_name from caregiver`",
+        output: "sql<{ middle_name: string | undefined; }>`select middle_name from caregiver`",
+        errors: [
+          { messageId: "incorrectTypeAnnotations", line: 1, column: 5, endLine: 1, endColumn: 35 },
+        ],
+      },
+      {
+        name: "without nullAsOptional while result is marked as optional",
+        filename,
+        options: withConnection(connections.withTag, {
+          nullAsUndefined: true,
+        }),
+        code: "sql<{ middle_name?: string | undefined }>`select middle_name from caregiver`",
+        output: "sql<{ middle_name: string | undefined; }>`select middle_name from caregiver`",
+        errors: [
+          { messageId: "incorrectTypeAnnotations", line: 1, column: 5, endLine: 1, endColumn: 41 },
+        ],
+      },
+      {
+        name: "with nullAsOptional while result is marked as required",
+        filename,
+        options: withConnection(connections.withTag, {
+          nullAsUndefined: true,
+          nullAsOptional: true,
+        }),
+        code: "sql<{ middle_name: string | undefined }>`select middle_name from caregiver`",
+        output: "sql<{ middle_name?: string | undefined; }>`select middle_name from caregiver`",
+        errors: [
+          { messageId: "incorrectTypeAnnotations", line: 1, column: 5, endLine: 1, endColumn: 40 },
+        ],
+      },
+    ],
+  });
+
   ruleTester.run("strict null check", rules["check-sql"], {
     valid: [
       {

--- a/packages/eslint-plugin/src/rules/check-sql.worker.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.worker.ts
@@ -113,6 +113,8 @@ function workerHandler(params: WorkerParams): TE.TaskEither<WorkerError, WorkerR
         pgParsed: params.pgParsed,
         overrides: params.connection.overrides,
         fieldTransform: params.target.fieldTransform,
+        nullAsUndefined: params.connection.nullAsUndefined,
+        nullAsOptional: params.connection.nullAsOptional,
       });
     }),
     TE.chainW(TE.fromEither)

--- a/packages/eslint-plugin/src/utils/get-type-properties.ts
+++ b/packages/eslint-plugin/src/utils/get-type-properties.ts
@@ -85,7 +85,9 @@ function getTypePropertiesFromTypeLiteral(params: {
       })
       .join(" | ");
 
-    properties.push([member.key.name, actualType]);
+    const key = member.optional ? `${member.key.name}?` : member.key.name;
+
+    properties.push([key, actualType]);
   }
 
   return properties;


### PR DESCRIPTION
This PR adds two configuration options:
- `nullAsUndefined`: type nullable values as `undefined` instead of `null`
- `nullAsOptional`: mark nullable properties as `optional`

I try to consistently only use `undefined` in my projects so I made a local patch for this, but I think this could be useful to others, as this convention is used by other people. 

Let me know what you think!