### PR TITLE
fix: issue with recursive custom column type ending with '[]'

### DIFF
--- a/.changeset/late-parrots-travel.md
+++ b/.changeset/late-parrots-travel.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/eslint-plugin": patch
+---
+
+fixed an issue with recursive custom column type that ends with "[]"

--- a/packages/eslint-plugin/src/utils/get-resolved-target-by-type-node.ts
+++ b/packages/eslint-plugin/src/utils/get-resolved-target-by-type-node.ts
@@ -12,6 +12,20 @@ type GetResolvedTargetByTypeNodeParams = {
 export function getResolvedTargetByTypeNode(
   params: GetResolvedTargetByTypeNodeParams,
 ): ResolvedTarget {
+  const asText = params.parser.esTreeNodeToTSNodeMap.get(params.typeNode).getText();
+
+  if (params.reservedTypes.has(asText)) {
+    return { kind: "type", value: asText };
+  }
+
+  if (params.reservedTypes.has(`${asText}[]`)) {
+    return { kind: "array", value: { kind: "type", value: asText } };
+  }
+
+  if (params.reservedTypes.has(`${asText}[]`)) {
+    return { kind: "array", value: { kind: "type", value: asText } };
+  }
+
   if (
     params.typeNode.type === TSESTree.AST_NODE_TYPES.TSLiteralType &&
     params.typeNode.literal.type === TSESTree.AST_NODE_TYPES.Literal
@@ -149,6 +163,11 @@ function getTypePropertiesFromTypeReference(params: {
     return { kind: "type", value: checker.typeToString(type) };
   }
 
+  if (reservedTypes.has(`${typeAsString}[]`)) {
+    const arrayType = typeAsString.replace("[]", "");
+    return { kind: "array", value: { kind: "type", value: arrayType } };
+  }
+
   switch (typeAsString) {
     case "string":
       return { kind: "type", value: "string" };
@@ -250,12 +269,6 @@ function getTypePropertiesFromTypeReference(params: {
         property,
         parser.esTreeNodeToTSNodeMap.get(typeNode),
       );
-
-      const propTypeString = checker.typeToString(propType);
-
-      if (reservedTypes.has(propTypeString)) {
-        return [key, { kind: "type", value: propTypeString }];
-      }
 
       return [
         key,


### PR DESCRIPTION
This commit fixes an issue with recursive custom column types that end with '[]'. The issue was identified in the eslint-plugin package and the necessary changes were made in the check-sql.test.ts and get-resolved-target-by-type-node.ts files.