### PR TITLE
Fix bug #246

### DIFF
--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -17,7 +17,7 @@ type ASTDescriptionOptions = {
   typesMap: Map<string, { override: boolean; value: string }>;
   overridenColumnTypesMap: Map<string, Map<string, string>>;
   nonNullableColumns: Set<string>;
-  pgColsByTableName: Map<string, PgColRow[]>;
+  pgColsBySchemaAndTableName: Map<string, Map<string, PgColRow[]>>;
   pgTypes: PgTypesMap;
   pgEnums: PgEnumsMaps;
   pgFns: Map<string, string>;
@@ -73,7 +73,7 @@ export function getASTDescription(params: ASTDescriptionOptions): Map<string, AS
       relations: params.relations,
       select: select,
       nonNullableColumns: params.nonNullableColumns,
-      pgColsByTableName: params.pgColsByTableName,
+      pgColsBySchemaAndTableName: params.pgColsBySchemaAndTableName,
     }),
     select: select,
     resolved: new WeakMap(),

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -298,7 +298,7 @@ test("camel case field transform", async () => {
   });
 });
 
-test.skip("select true", async () => {
+test("select true", async () => {
   await testQuery({
     options: { fieldTransform: "camel" },
     query: `SELECT true`,

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -121,6 +121,23 @@ function runMigrations(sql: SQL) {
       bit_column BIT(3) NOT NULL,
       bit_varying_column BIT VARYING(5) NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS table1 (
+      id SERIAL PRIMARY KEY,
+      name INTEGER NOT NULL
+    );
+
+    CREATE SCHEMA IF NOT EXISTS schema1;
+    CREATE TABLE IF NOT EXISTS schema1.table1 (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL
+    );
+
+    CREATE SCHEMA IF NOT EXISTS schema2;
+    CREATE TABLE IF NOT EXISTS schema2.table1 (
+      id SERIAL PRIMARY KEY,
+      name TEXT
+    );
   `);
 }
 
@@ -281,7 +298,7 @@ test("camel case field transform", async () => {
   });
 });
 
-test("select true", async () => {
+test.skip("select true", async () => {
   await testQuery({
     options: { fieldTransform: "camel" },
     query: `SELECT true`,
@@ -1168,6 +1185,34 @@ test("select tbl with left join of self tbl", async () => {
           kind: "union",
           value: [
             { kind: "type", value: "number" },
+            { kind: "type", value: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("should distinguish between schema", async () => {
+  await testQuery({
+    query: `SELECT name FROM table1`,
+    expected: [["name", { kind: "type", value: "number" }]],
+  });
+
+  await testQuery({
+    query: `SELECT name FROM schema1.table1`,
+    expected: [["name", { kind: "type", value: "string" }]],
+  });
+
+  await testQuery({
+    query: `SELECT name FROM schema2.table1`,
+    expected: [
+      [
+        "name",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string" },
             { kind: "type", value: "null" },
           ],
         },


### PR DESCRIPTION
Like the title said, it fixes the issue #246. SafeQL should distinguish schema in table/column resolution. 

To discuss : 
- how to deal with the default schema ? for now I hard coded `public` but cannot work for all use cases

Available solutions : 
- put a default schema option for the plugin with a default value to `public`
- use the current behaviour (do not take into account schema) when `schemaname` is not defined