### PR TITLE
Use SQL commands instead of createdb and dropdb

### DIFF
--- a/.changeset/six-mayflies-promise.md
+++ b/.changeset/six-mayflies-promise.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/eslint-plugin": minor
+---
+
+Removed calls to createdb and dropdb and replaced them with SQL commands

--- a/packages/eslint-plugin/src/utils/connection-manager.ts
+++ b/packages/eslint-plugin/src/utils/connection-manager.ts
@@ -12,7 +12,7 @@ export function createConnectionManager() {
   const connectionMap: Map<string, Sql> = new Map();
 
   return {
-    getOrCreate: (databaseUrl: string, options?: postgres.Options<{}>) =>
+    getOrCreate: (databaseUrl: string, options?: postgres.Options<never>) =>
       getOrCreateConnection(databaseUrl, connectionMap, options),
     close: (params: CloseConnectionParams) => closeConnection(params, connectionMap),
   };
@@ -21,7 +21,7 @@ export function createConnectionManager() {
 function getOrCreateConnection(
   databaseUrl: string,
   connectionMap: Map<string, Sql>,
-  options?: postgres.Options<{}>,
+  options?: postgres.Options<never>,
 ): ConnectionPayload {
   return pipe(
     O.fromNullable(connectionMap.get(databaseUrl)),

--- a/packages/eslint-plugin/src/utils/connection-manager.ts
+++ b/packages/eslint-plugin/src/utils/connection-manager.ts
@@ -12,7 +12,8 @@ export function createConnectionManager() {
   const connectionMap: Map<string, Sql> = new Map();
 
   return {
-    getOrCreate: (databaseUrl: string) => getOrCreateConnection(databaseUrl, connectionMap),
+    getOrCreate: (databaseUrl: string, options?: postgres.Options<{}>) =>
+      getOrCreateConnection(databaseUrl, connectionMap, options),
     close: (params: CloseConnectionParams) => closeConnection(params, connectionMap),
   };
 }
@@ -20,12 +21,13 @@ export function createConnectionManager() {
 function getOrCreateConnection(
   databaseUrl: string,
   connectionMap: Map<string, Sql>,
+  options?: postgres.Options<{}>,
 ): ConnectionPayload {
   return pipe(
     O.fromNullable(connectionMap.get(databaseUrl)),
     O.foldW(
       () => {
-        const sql = postgres(databaseUrl);
+        const sql = postgres(databaseUrl, options);
         connectionMap.set(databaseUrl, sql);
         return { sql, databaseUrl, isFirst: true };
       },
@@ -55,9 +57,14 @@ function closeConnection(params: CloseConnectionParams, connectionMap: Map<strin
       const connectionOptions = { ...parseConnection(connectionUrl), database: databaseName };
       const databaseUrl = mapConnectionOptionsToString(connectionOptions);
       const sql = connectionMap.get(databaseUrl);
+      const migrationSql = connectionMap.get(connectionUrl);
       if (sql) {
         sql.end();
         connectionMap.delete(databaseUrl);
+      }
+      if (migrationSql) {
+        migrationSql.end();
+        connectionMap.delete(connectionUrl);
       }
     })
     .exhaustive();


### PR DESCRIPTION
Fixes: #245

Removes calls to `createdb` and `dropdb` and replaces them with SQL commands. This means the user will not need to install the PostgreSQL client to use this tool.