### PR TITLE
fix: issue with queries containing union

### DIFF
--- a/.changeset/seven-pianos-bathe.md
+++ b/.changeset/seven-pianos-bathe.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+fixed an issue where a query with union would fail

--- a/packages/ast-types/src/index.ts
+++ b/packages/ast-types/src/index.ts
@@ -890,7 +890,7 @@ export interface MergeStmt {
 export interface SelectStmt {
   distinctClause: Node[];
   intoClause: IntoClause | undefined;
-  targetList: Node[];
+  targetList?: Node[];
   fromClause?: Node[];
   whereClause: Node | undefined;
   groupClause: Node[];
@@ -2345,13 +2345,13 @@ enum CTEMaterialize {
   UNRECOGNIZED = -1,
 }
 
-enum SetOperation {
-  SET_OPERATION_UNDEFINED = 0,
-  SETOP_NONE = 1,
-  SETOP_UNION = 2,
-  SETOP_INTERSECT = 3,
-  SETOP_EXCEPT = 4,
-  UNRECOGNIZED = -1,
+export enum SetOperation {
+  SET_OPERATION_UNDEFINED = "SET_OPERATION_UNDEFINED",
+  SETOP_NONE = "SETOP_NONE",
+  SETOP_UNION = "SETOP_UNION",
+  SETOP_INTERSECT = "SETOP_INTERSECT",
+  SETOP_EXCEPT = "SETOP_EXCEPT",
+  UNRECOGNIZED = "UNRECOGNIZED",
 }
 
 enum ObjectType {

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -116,10 +116,10 @@ export function getASTDescription(params: ASTDescriptionOptions): Map<string, AS
   };
 
   const targetList = [
-    ...select.targetList ?? [],
-    ...select.larg?.targetList ?? [],
-    ...select.rarg?.targetList ?? [],
-  ]
+    ...(select.targetList ?? []),
+    ...(select.larg?.targetList ?? []),
+    ...(select.rarg?.targetList ?? []),
+  ];
 
   const result = targetList
     .map((node) => getDescribedNode({ alias: undefined, node, context }))

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -115,7 +115,13 @@ export function getASTDescription(params: ASTDescriptionOptions): Map<string, AS
     },
   };
 
-  const result = select.targetList
+  const targetList = [
+    ...select.targetList ?? [],
+    ...select.larg?.targetList ?? [],
+    ...select.rarg?.targetList ?? [],
+  ]
+
+  const result = targetList
     .map((node) => getDescribedNode({ alias: undefined, node, context }))
     .flat();
 

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -202,7 +202,7 @@ const testQuery = async (params: {
           params.expectedError,
           O.fromNullable,
           O.fold(
-            () => assert.fail(error),
+            () => assert.fail(error.stack),
             (expectedError) => assert.strictEqual(error.message, expectedError),
           ),
         ),
@@ -1190,6 +1190,23 @@ test("select tbl with left join of self tbl", async () => {
         },
       ],
     ],
+  });
+});
+
+test("select union select", async () => {
+  await testQuery({
+    query: `SELECT 1 UNION SELECT 2`,
+    expected: [["?column?", { kind: "type", value: "number" }]],
+  });
+
+  await testQuery({
+    query: `SELECT 1 as a UNION SELECT 2 as b`,
+    expected: [["a", { kind: "type", value: "number" }]],
+  });
+
+  await testQuery({
+    query: `SELECT 'Hello' UNION SELECT 7;`,
+    expectedError: 'invalid input syntax for type integer: "Hello"',
   });
 });
 

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -282,7 +282,7 @@ async function generate(
       query: query,
     });
   } catch (e) {
-    if (e instanceof postgres.PostgresError) {
+    if (isPostgresError(e)) {
       return either.left(
         PostgresError.of({
           queryText: query,
@@ -295,6 +295,18 @@ async function generate(
 
     throw e;
   }
+}
+
+function isPostgresError(e: unknown): e is postgres.PostgresError {
+  if (e instanceof postgres.PostgresError) {
+    return true;
+  }
+
+  if (e instanceof Error && e.name === "PostgresError") {
+    return true;
+  }
+
+  return false;
 }
 
 async function getDatabaseMetadata(sql: Sql) {

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -257,7 +257,13 @@ function getNonNullableColumnsInSelectStmt(
 ): Set<string> {
   const nonNullableColumns = new Set<string>();
 
-  for (const target of stmt.targetList) {
+  const targetList = [
+    ...(stmt.targetList ?? []),
+    ...(stmt.larg?.targetList ?? []),
+    ...(stmt.rarg?.targetList ?? []),
+  ];
+
+  for (const target of targetList) {
     if (target.ResTarget && isColumnNonNullable(target.ResTarget.val, root)) {
       nonNullableColumns.add(getTargetName(target.ResTarget));
     }


### PR DESCRIPTION
fixes https://github.com/ts-safeql/safeql/issues/241

This commit fixes an issue where a query containing a union would fail. Now, such queries are handled correctly and do not cause any errors.