### PR TITLE
Move @typescript-eslint/utils from deps to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
     "turbo": "^1.13.3",
     "typescript": "^5.4.5"
   },
-  "packageManager": "pnpm@9.1.4"
+  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -56,7 +56,6 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^7.8.0",
     "chokidar": "^3.6.0",
     "fp-ts": "^2.16.5",
     "pg-connection-string": "2.5.0",
@@ -68,6 +67,7 @@
     "zod-to-json-schema": "3.20.1"
   },
   "peerDependencies": {
+    "@typescript-eslint/utils": ">=7.8.0",
     "libpg-query": ">=13.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,7 +520,7 @@ importers:
   packages/eslint-plugin:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^7.8.0
+        specifier: '>=7.8.0'
         version: 7.11.0(eslint@8.57.0)(typescript@5.4.5)
       chokidar:
         specifier: ^3.6.0


### PR DESCRIPTION
Closes #258

@Newbie012 what do you think about allowing projects to specify their version of `@typescript-eslint/utils` like this?