### PR TITLE
Fix nullability for CASE WHEN with equality expression

### DIFF
--- a/.changeset/lucky-phones-camp.md
+++ b/.changeset/lucky-phones-camp.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Fix nullability for CASE WHEN with equality expression

--- a/packages/generate/src/utils/get-nonnullable-columns.test.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.test.ts
@@ -29,6 +29,7 @@ const cases: {
   { query: `SELECT 10 - 2`, expected: ["?column?"] },
   { query: `SELECT 10 + 2`, expected: ["?column?"] },
   { query: `SELECT CASE WHEN true THEN 1 ELSE 0 END`, expected: ["case"] },
+  { query: `SELECT CASE WHEN 1 = 1 THEN 1 ELSE 0 END`, expected: ["case"] },
   { query: `SELECT tbl.col FROM tbl WHERE tbl.col IS NOT NULL`, expected: ["tbl.col"] },
   {
     query: `SELECT tbl.col IS NOT NULL AS is_col_not_null FROM tbl`,

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -137,8 +137,7 @@ function isColumnNonNullable(
 
   if (val.CaseExpr) {
     for (const when of val.CaseExpr.args) {
-      if (!isColumnNonNullable(when.CaseWhen?.result, root)
-      ) {
+      if (!isColumnNonNullable(when.CaseWhen?.result, root)) {
         return false;
       }
     }

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -137,9 +137,7 @@ function isColumnNonNullable(
 
   if (val.CaseExpr) {
     for (const when of val.CaseExpr.args) {
-      if (
-        !isColumnNonNullable(when.CaseWhen?.expr, root) ||
-        !isColumnNonNullable(when.CaseWhen?.result, root)
+      if (!isColumnNonNullable(when.CaseWhen?.result, root)
       ) {
         return false;
       }


### PR DESCRIPTION
Fix column being incorrectly inferred as nullable:

```ts
// 💥 Query has incorrect type annotation.
//	Expected: { has_private_url: boolean; }
//	Actual: { has_private_url: boolean | null; }[]
await sql<{ has_private_url: boolean }[]>`
  SELECT
    CASE
      WHEN profile_video_id = ${profileVideoId} THEN profile_url_private IS NOT NULL
      WHEN cover_video_id = ${coverVideoId} THEN cover_url_private IS NOT NULL
    END AS has_private_url
  FROM
    users
`;
```

This fails because:

1. `x = y` is inferred to be nullable
2. The `WHEN` expression (`CaseWhen.expr`) is being checked for nullability, which doesn't seem to make sense, if I understand correctly how SQL is parsed

I only fixed 2 in this PR (removed the nullability check for `CaseWhen.expr`), but in future PRs, we should also fix 1.

TODO:

- [x] Add a test