### PR TITLE
Make LIKE and NOT LIKE expressions non-nullable

### DIFF
--- a/.changeset/long-toes-brush.md
+++ b/.changeset/long-toes-brush.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Make LIKE and NOT LIKE expressions non-nullable

--- a/packages/generate/src/utils/get-nonnullable-columns.test.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.test.ts
@@ -29,6 +29,8 @@ const cases: {
   { query: `SELECT 10 - 2`, expected: ["?column?"] },
   { query: `SELECT 10 + 2`, expected: ["?column?"] },
   { query: `SELECT CASE WHEN true THEN 1 ELSE 0 END`, expected: ["case"] },
+  { query: `SELECT tbl.col LIKE 'abc%' AS col_like FROM tbl`, expected: ["col_like"] },
+  { query: `SELECT tbl.col NOT LIKE 'abc%' AS col_not_like FROM tbl`, expected: ["col_not_like"] },
   { query: `SELECT tbl.col FROM tbl WHERE tbl.col IS NOT NULL`, expected: ["tbl.col"] },
   {
     query: `SELECT tbl.col IS NOT NULL AS is_col_not_null FROM tbl`,

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -129,6 +129,10 @@ function isColumnNonNullable(
     }
   }
 
+  if (val.A_Expr?.kind === LibPgQueryAST.AExprKind.AEXPR_LIKE) {
+    return true;
+  }
+
   if (val.A_Expr?.kind === LibPgQueryAST.AExprKind.AEXPR_OP) {
     return (
       isColumnNonNullable(val.A_Expr.lexpr, root) && isColumnNonNullable(val.A_Expr.rexpr, root)


### PR DESCRIPTION
Fix column being incorrectly inferred as nullable:

```ts
// 💥 Query has incorrect type annotation.
//	Expected: { is_guest: boolean; }
//	Actual: { is_guest: boolean | null; }[]
await sql<{ is_guest: boolean }[]>`
  SELECT
    lecturers.id,
    users.email NOT LIKE '%@upleveled.io' AS is_guest
  FROM
    lecturers
    INNER JOIN users ON lecturers.user_id = users.id
`;
```
