### PR TITLE
fix: correct type inference for nullable and unknown types

### DIFF
--- a/.changeset/dirty-lizards-shake.md
+++ b/.changeset/dirty-lizards-shake.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+fixed an issue where type could be inferred as unknown and nullable when using aliases in some cases

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -306,7 +306,7 @@ function getDescribedTypeCast({
   }
 
   const type = context.toTypeScriptType({ name: typeName });
-  const innerDescribed = getDescribedNode({ alias: undefined, node: node.arg, context }).at(0);
+  const innerDescribed = getDescribedNode({ alias, node: node.arg, context }).at(0);
   const nullable = fmap(innerDescribed, (x) => isDescribedColumnNullable(x.type)) ?? true;
 
   switch (true) {
@@ -395,12 +395,16 @@ function getDescribedFuncCallByPgFn({
     return [];
   });
 
+  if (functionName === undefined) {
+    return [{ name, type: context.toTypeScriptType({ name: "unknown" }) }];
+  }
+
   const pgFnValue =
     args.length === 0
-      ? context.pgFns.get(name)
-      : context.pgFns.get(`${name}(${args.join(", ")})`) ??
-        context.pgFns.get(`${name}(any)`) ??
-        context.pgFns.get(`${name}(unknown)`);
+      ? context.pgFns.get(functionName)
+      : context.pgFns.get(`${functionName}(${args.join(", ")})`) ??
+        context.pgFns.get(`${functionName}(any)`) ??
+        context.pgFns.get(`${functionName}(unknown)`);
 
   const type = resolveType({
     context: context,

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -327,6 +327,20 @@ test("select count(1)::int as col should be non-nullable", async () => {
   });
 });
 
+test("SELECT id FROM caregiver tbl WHERE tbl.id IS NOT NULL", async () => {
+  await testQuery({
+    query: `SELECT id FROM caregiver tbl WHERE tbl.id IS NOT NULL`,
+    expected: [["id", { kind: "type", value: "number" }]],
+  });
+});
+
+test("SELECT tbl.id FROM caregiver tbl WHERE tbl.id IS NOT NULL", async () => {
+  await testQuery({
+    query: `SELECT tbl.id FROM caregiver tbl WHERE tbl.id IS NOT NULL`,
+    expected: [["id", { kind: "type", value: "number" }]],
+  });
+});
+
 test("select sum", async () => {
   await testQuery({
     query: `SELECT sum(id) from caregiver`,

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -313,6 +313,20 @@ test("select count(1) should be non-nullable", async () => {
   });
 });
 
+test("select count(1) as col should be non-nullable", async () => {
+  await testQuery({
+    query: `SELECT count(1) as col`,
+    expected: [["col", { kind: "type", value: "string" }]],
+  });
+});
+
+test("select count(1)::int as col should be non-nullable", async () => {
+  await testQuery({
+    query: `SELECT count(1)::int as col`,
+    expected: [["col", { kind: "type", value: "number" }]],
+  });
+});
+
 test("select sum", async () => {
   await testQuery({
     query: `SELECT sum(id) from caregiver`,

--- a/packages/generate/src/utils/get-nonnullable-columns.test.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.test.ts
@@ -74,6 +74,8 @@ const cases: {
   { query: `SELECT GREATEST(1, NULL, 3)`, expected: [] },
   { query: `SELECT LEAST(1, NULL, 3)`, expected: [] },
   { query: `SELECT a, b FROM tbl WHERE b IS NOT NULL OR a IS NOT NULL`, expected: [] },
+  { query: `SELECT col FROM mytable tbl WHERE psa.col IS NOT NULL`, expected: ["col"] },
+  { query: `SELECT tbl.col FROM tbl WHERE tbl.col IS NOT NULL`, expected: ["tbl.col"] },
 ];
 
 export const getNonNullableColumnsTE = flow(


### PR DESCRIPTION
fixes https://github.com/ts-safeql/safeql/issues/273

This commit fixes an issue where the type could be inferred as unknown and nullable when using aliases in some cases. The changes include modifications to the getDescribedTypeCast and getDescribedFuncCallByPgFn functions in the ast-describe.ts file, and additional tests have been added to ensure the correct behavior.