### PR TITLE
fix: improve error message for duplicate columns with alias

### DIFF
--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -1303,3 +1303,16 @@ test("should distinguish between schema", async () => {
     ],
   });
 });
+
+test("select with duplicate columns and alias", async () => {
+  await testQuery({
+    query: `
+      SELECT
+        caregiver.id as x,
+        caregiver_certification.caregiver_id as x
+      FROM caregiver
+        JOIN caregiver_certification ON caregiver.id = caregiver_certification.caregiver_id
+    `,
+    expectedError: `Duplicate columns: caregiver.id (alias: x), caregiver_certification.caregiver_id (alias: x)`,
+  });
+});


### PR DESCRIPTION
This change enhances the error message for queries with duplicate columns by including alias information, making it clearer which columns are causing the conflict.

fix #291