### PR TITLE
fix: handle typescript enums correctly in SQL checks

### DIFF
--- a/.changeset/long-oranges-pull.md
+++ b/.changeset/long-oranges-pull.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/eslint-plugin": patch
+---
+
+fixed an issue where typescript enums weren't processed properly in some cases

--- a/packages/eslint-plugin/src/rules/check-sql.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.test.ts
@@ -270,6 +270,17 @@ RuleTester.describe("check-sql", () => {
         `,
       },
       {
+        name: "compare typescript enum with postgres enum",
+        filename,
+        options: withConnection(connections.withTag),
+        code: `
+          enum Certification { HHA = "HHA", RN = "RN" }
+          function foo(cert: Certification) {
+            sql\`select from caregiver where certification = \${cert}\`
+          }
+        `,
+      },
+      {
         name: "select from table with inner joins",
         filename,
         options: withConnection(connections.base),
@@ -834,6 +845,25 @@ RuleTester.describe("check-sql", () => {
           },
         ],
       },
+      {
+        name: "incorrect comparison of typescript <> postgres enum",
+        filename,
+        options: withConnection(connections.withTag),
+        code: normalizeIndent`
+          enum Certification { HHA = "HHA", RN = "RM" }
+          function foo(cert: Certification) {
+            sql\`select from caregiver where certification = \${cert}\`
+          }
+        `,
+        errors: [
+          {
+            messageId: "invalidQuery",
+            data: {
+              error: 'invalid input value for enum certification: "RM"',
+            },
+          },
+        ],
+      },
     ],
   });
 
@@ -1105,7 +1135,6 @@ RuleTester.describe("check-sql", () => {
           interface Parameter<T> { value: T; }
           class LocalDate {}
           function run(simple: LocalDate, parameterized: Parameter<LocalDate>) {
-            sql<{ date_col: LocalDate }>\`select date_col from test_date_column WHERE date_col = \${simple}\`
             sql<{ date_col: LocalDate }>\`select date_col from test_date_column WHERE date_col = \${parameterized}\`
           }
         `,

--- a/packages/eslint-plugin/src/utils/ts-pg.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts-pg.utils.ts
@@ -220,9 +220,6 @@ function getPgTypeFromTsType(params: {
 }): E.Either<string, PgTypeStrategy | null> {
   const { checker, node, type, options } = params;
 
-  // Utility function to get PostgreSQL type from flags
-  const getPgTypeFromFlags = (flags: ts.TypeFlags) => tsFlagToPgTypeMap[flags];
-
   // Check for conditional expression
   if (node.kind === ts.SyntaxKind.ConditionalExpression) {
     const whenTrueType = getPgTypeFromFlags(checker.getTypeAtLocation(node.whenTrue).flags);
@@ -261,6 +258,19 @@ function getPgTypeFromTsType(params: {
           )
         : E.left("Invalid array union type");
     }
+
+    if (
+      checker.isArrayType(type) &&
+      TSUtils.isTsTypeReference(type) &&
+      type.typeArguments?.length === 1
+    ) {
+      const typeArgument = type.typeArguments?.[0];
+
+      return pipe(
+        checkType({ checker, type: typeArgument, options }),
+        E.map((pgType): PgTypeStrategy => ({ kind: "cast", cast: `${pgType.cast}[]` })),
+      );
+    }
   }
 
   if (node.kind === ts.SyntaxKind.StringLiteral) {
@@ -290,6 +300,20 @@ function getPgTypeFromTsType(params: {
       : E.left("Unsupported union type");
   }
 
+  return checkType({ checker, type, options });
+}
+
+function getPgTypeFromFlags(flags: ts.TypeFlags) {
+  return tsFlagToPgTypeMap[flags];
+}
+
+function checkType(params: {
+  checker: TypeChecker;
+  type: ts.Type;
+  options: RuleOptionConnection;
+}): E.Either<string, PgTypeStrategy> {
+  const { checker, type, options } = params;
+
   // Handle array types
   const typeStr = checker.typeToString(type);
   const singularType = typeStr.replace(/\[\]$/, "");
@@ -307,6 +331,20 @@ function getPgTypeFromTsType(params: {
       elementType.types.every((t) => t.flags === elementType.types[0].flags)
     ) {
       return E.right({ kind: "cast", cast: `${getPgTypeFromFlags(elementType.types[0].flags)}[]` });
+    }
+  }
+
+  const enumType = TSUtils.getEnumKind(type);
+
+  if (enumType) {
+    switch (enumType.kind) {
+      case "Const":
+      case "Numeric":
+        return E.right({ kind: "cast", cast: "int" });
+      case "String":
+        return E.right({ kind: "one-of", types: enumType.values, cast: "text" });
+      case "Heterogeneous":
+        return E.left("Heterogeneous enums are not supported");
     }
   }
 

--- a/packages/eslint-plugin/src/utils/ts.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts.utils.ts
@@ -1,5 +1,11 @@
 import ts from "typescript";
 
+type EnumKind =
+  | { kind: "Const" }
+  | { kind: "Numeric" }
+  | { kind: "String"; values: string[] }
+  | { kind: "Heterogeneous" };
+
 export const TSUtils = {
   isTypeUnion: (typeNode: ts.TypeNode | undefined): typeNode is ts.UnionTypeNode => {
     return typeNode?.kind === ts.SyntaxKind.UnionType;
@@ -31,5 +37,57 @@ export const TSUtils = {
   },
   isTsObjectType(type: ts.Type): type is ts.ObjectType {
     return type.flags === ts.TypeFlags.Object;
+  },
+  getEnumKind(type: ts.Type): EnumKind | undefined {
+    const symbol = type.getSymbol();
+    if (!symbol || !(symbol.flags & ts.SymbolFlags.Enum)) {
+      return undefined; // Not an enum
+    }
+
+    const declarations = symbol.getDeclarations();
+    if (!declarations) {
+      return undefined;
+    }
+
+    let hasString = false;
+    let hasNumeric = false;
+    const stringValues: string[] = [];
+
+    for (const declaration of declarations) {
+      if (ts.isEnumDeclaration(declaration)) {
+        for (const member of declaration.members) {
+          const initializer = member.initializer;
+
+          if (initializer) {
+            if (ts.isStringLiteralLike(initializer)) {
+              hasString = true;
+              stringValues.push(initializer.text);
+            }
+
+            if (initializer.kind === ts.SyntaxKind.NumericLiteral) {
+              hasNumeric = true;
+            }
+          } else {
+            // Members without initializers are numeric by default
+            hasNumeric = true;
+          }
+        }
+      }
+    }
+
+    // Determine the kind of enum
+    if (symbol.flags & ts.SymbolFlags.ConstEnum) {
+      return { kind: "Const" };
+    }
+
+    if (hasString && hasNumeric) {
+      return { kind: "Heterogeneous" };
+    }
+
+    if (hasString) {
+      return { kind: "String", values: stringValues };
+    }
+
+    return { kind: "Numeric" };
   },
 };


### PR DESCRIPTION
Fixed an issue where TypeScript enums were not processed properly in some cases when comparing with PostgreSQL enums.