### PR TITLE
fix: handle AExpr and NullTest nodes in SQL parsing

### DIFF
--- a/.changeset/olive-coins-travel.md
+++ b/.changeset/olive-coins-travel.md
@@ -1,0 +1,6 @@
+---
+"@ts-safeql/eslint-plugin": patch
+"@ts-safeql/generate": patch
+---
+
+fixed an issue when dealing with AExpr and NullTest nodes

--- a/packages/eslint-plugin/src/rules/check-sql.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.test.ts
@@ -1277,6 +1277,27 @@ RuleTester.describe("check-sql", () => {
         }),
         code: "sql<{ phone_number: PhoneNumber }>`select phone_number from caregiver_phone`",
       },
+      {
+        name: 'select case when then jsonb with not like with type reference',
+        filename,
+        options: withConnection(connections.withTag, {
+          targets: [{ tag: "sql", transform: "{type}[]" }],
+        }),
+        code: `
+          type Meta = { is_test: boolean; };
+          type Caregiver = { meta: Meta | null };
+
+          await sql<Caregiver[]>\`
+            SELECT
+              CASE WHEN caregiver.id IS NOT NULL
+                THEN jsonb_build_object('is_test', caregiver.middle_name NOT LIKE '%test%')
+                ELSE NULL
+              END AS meta
+            FROM
+              caregiver
+          \`;
+        `,
+      },
     ],
     invalid: [
       {

--- a/packages/eslint-plugin/src/rules/check-sql.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.test.ts
@@ -1278,7 +1278,7 @@ RuleTester.describe("check-sql", () => {
         code: "sql<{ phone_number: PhoneNumber }>`select phone_number from caregiver_phone`",
       },
       {
-        name: 'select case when then jsonb with not like with type reference',
+        name: "select case when then jsonb with not like with type reference",
         filename,
         options: withConnection(connections.withTag, {
           targets: [{ tag: "sql", transform: "{type}[]" }],

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -202,7 +202,47 @@ function getDescribedNode(params: {
     return getDescribedCaseExpr({ alias: alias, node: node.CaseExpr, context });
   }
 
+  if (node.NullTest !== undefined) {
+    return getDescribedNullTest({ alias: alias, node: node.NullTest, context });
+  }
+
+  if (node.A_Expr !== undefined) {
+    return getDescribedAExpr({ alias: alias, node: node.A_Expr, context });
+  }
+
   return [];
+}
+
+function getDescribedAExpr({
+  alias,
+  context,
+}: GetDescribedParamsOf<LibPgQueryAST.AExpr>): ASTDescribedColumn[] {
+  return [
+    {
+      name: alias ?? "?column?",
+      type: resolveType({
+        context: context,
+        nullable: false,
+        type: context.toTypeScriptType({ name: "boolean" }),
+      }),
+    },
+  ];
+}
+
+function getDescribedNullTest({
+  alias,
+  context,
+}: GetDescribedParamsOf<LibPgQueryAST.NullTest>): ASTDescribedColumn[] {
+  return [
+    {
+      name: alias ?? "?column?",
+      type: resolveType({
+        context: context,
+        nullable: false,
+        type: context.toTypeScriptType({ name: "boolean" }),
+      }),
+    },
+  ];
 }
 
 function getDescribedCaseExpr({

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -1500,3 +1500,46 @@ test("select case when expr with returned string literals", async () => {
     expected: [["case", { kind: "type", value: "boolean" }]],
   });
 });
+
+test("select case when expr is not null else is not null", async () => {
+  await testQuery({
+    query: `
+      SELECT
+        CASE WHEN TRUE
+          THEN caregiver.id IS NOT NULL
+          ELSE caregiver.id IS NOT NULL
+        END
+      FROM caregiver`,
+    expected: [["case", { kind: "type", value: "boolean" }]],
+  });
+});
+
+test("select case when with jsonb_build_object", async () => {
+  await testQuery({
+    query: `
+      SELECT
+        CASE
+          WHEN caregiver.id IS NOT NULL THEN (
+            jsonb_build_object(
+              'is_test',
+              caregiver.first_name NOT LIKE '%test%'
+            )
+          )
+          ELSE NULL
+        END AS col
+      FROM
+        caregiver`,
+    expected: [
+      [
+        "col",
+        {
+          kind: "union",
+          value: [
+            { kind: "object", value: [["is_test", { kind: "type", value: "boolean" }]] },
+            { kind: "type", value: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});


### PR DESCRIPTION
fixes https://github.com/ts-safeql/safeql/issues/352 https://github.com/ts-safeql/safeql/issues/353