### PR TITLE
hotfix: fetch the proper res target name from subselect

### DIFF
--- a/.changeset/sharp-hairs-share.md
+++ b/.changeset/sharp-hairs-share.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+fixed an issue when dealing with column reference alias inside a subselect

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -39,7 +39,7 @@ export type ASTDescribedColumnType =
   | { kind: "union"; value: ASTDescribedColumnType[] }
   | { kind: "array"; value: ASTDescribedColumnType }
   | { kind: "object"; value: [string, ASTDescribedColumnType][] }
-  | { kind: "type"; value: string; type: string }
+  | { kind: "type"; value: string; type: string; base?: string }
   | { kind: "literal"; value: string; base: ASTDescribedColumnType };
 
 export function getASTDescription(params: ASTDescriptionOptions): Map<number, ASTDescribedColumn> {
@@ -132,6 +132,10 @@ export function getASTDescription(params: ASTDescriptionOptions): Map<number, AS
         value: value,
         type: params.pgTypes.get(p.oid)?.name ?? "unknown",
       };
+
+      if (p.baseOid !== null) {
+        type.base = params.pgTypes.get(p.baseOid)?.name;
+      }
 
       return isArray ? { kind: "array", value: type } : type;
     },
@@ -264,7 +268,7 @@ function getDescribedAExpr({
     }
 
     if (column.type.kind === "type") {
-      return { value: column.type.type, nullable: false };
+      return { value: column.type.base ?? column.type.type, nullable: false };
     }
 
     if (column.type.kind === "literal" && column.type.base.kind === "type") {

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -27,7 +27,7 @@ type JSToPostgresTypeMap = Record<string, unknown>;
 type Sql = postgres.Sql<JSToPostgresTypeMap>;
 
 export type ResolvedTarget =
-  | { kind: "type"; value: string; type: string }
+  | { kind: "type"; value: string; type: string; base?: string }
   | { kind: "literal"; value: string; base: ResolvedTarget }
   | { kind: "union"; value: ResolvedTarget[] }
   | { kind: "array"; value: ResolvedTarget; syntax?: "array-type" | "type-reference" }
@@ -444,7 +444,7 @@ function getResolvedTargetEntry(params: {
 }): ResolvedTargetEntry {
   if (params.col.astDescribed !== undefined) {
     return [
-      toCase(params.col.astDescribed.name, params.context.fieldTransform),
+      toCase(params.col.described.name, params.context.fieldTransform),
       params.col.astDescribed.type,
     ];
   }

--- a/packages/generate/src/utils/get-relations-with-joins.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.ts
@@ -58,7 +58,11 @@ function recursiveTraverseJoins(
     return recursiveTraverseJoins([join, ...joins], joinExpr.rarg?.JoinExpr);
   }
 
-  const relName = joinExpr.larg?.RangeVar?.relname ?? joinExpr.rarg?.RangeVar?.relname;
+  const relName =
+    joinExpr.larg?.RangeVar?.relname ??
+    joinExpr.larg?.RangeFunction?.alias?.aliasname ??
+    joinExpr.rarg?.RangeVar?.relname ??
+    joinExpr.rarg?.RangeFunction?.alias?.aliasname;
 
   if (relName === undefined) {
     throw new Error("relName is undefined");


### PR DESCRIPTION
fixes https://github.com/ts-safeql/safeql/issues/364, https://github.com/ts-safeql/safeql/issues/363, https://github.com/ts-safeql/safeql/issues/362