### PR TITLE
fix: Support type overrides in RETURNING clause

### DIFF
--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -639,6 +639,33 @@ test("insert into table without returning", async () => {
   });
 });
 
+test("insert into table with overridden type in RETURNING", async () => {
+  await testQuery({
+    options: { overrides: { types: { text: "CustomType" } } },
+    query: `INSERT INTO agency (name) VALUES ('overriden_type_inserted') RETURNING name`,
+    expected: [["name", { kind: "type", value: "CustomType", type: "text" }]],
+    unknownColumns: ["name"],
+  });
+});
+
+test("update row with overridden type in RETURNING", async () => {
+  await testQuery({
+    options: { overrides: { types: { text: "CustomType" } } },
+    query: `UPDATE agency SET name = 'overriden_type_updated' WHERE name = 'overriden_type_inserted' RETURNING name`,
+    expected: [["name", { kind: "type", value: "CustomType", type: "text" }]],
+    unknownColumns: ["name"],
+  });
+});
+
+test("delete row with overridden type in RETURNING", async () => {
+  await testQuery({
+    options: { overrides: { types: { text: "CustomType" } } },
+    query: `DELETE FROM agency WHERE name = 'overriden_type_updated' RETURNING name`,
+    expected: [["name", { kind: "type", value: "CustomType", type: "text" }]],
+    unknownColumns: ["name"],
+  });
+});
+
 test("insert into returning overriden column", async () => {
   await testQuery({
     schema: `

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -481,7 +481,7 @@ function getResolvedTargetEntry(params: {
 
     if (!pgType) return undefined;
 
-    if (params.context.overrides?.columns) {
+    if (params.context.overrides?.columns && params.context.overrides.columns.size > 0) {
       const override = params.context.overrides.columns
         .get(params.col.introspected?.tableName ?? "")
         ?.get(params.col.described.name);


### PR DESCRIPTION
- Ensure column type overrides are respected in INSERT, UPDATE, and DELETE statements that use the RETURNING clause.
- Add test cases for overridden text type in RETURNING.

Fixes #388