### PR TITLE
fix jsonb operator nullability inference

### DIFF
--- a/.changeset/clever-rockets-act.md
+++ b/.changeset/clever-rockets-act.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Fixed jsonb `->>` and `#>>` operators to correctly infer nullable types when left expressions contain column references.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly infers nullable types for JSONB operators (->>, #>>) when paths depend on column values.
  - Ensures literal-path extraction returns non-null strings.
  - Improves nullability handling for jsonb_build_object with mixed column/literal inputs.

- Tests
  - Expanded test coverage for JSONB extraction and nullability scenarios.

- Chores
  - Added changeset to publish a patch release of @ts-safeql/generate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->