### PR TITLE
fix: apply column overrides correctly with aliased columns in RETURNING clause

### DIFF
--- a/.changeset/fresh-beers-open.md
+++ b/.changeset/fresh-beers-open.md
@@ -1,0 +1,6 @@
+---
+"@ts-safeql/generate": patch
+---
+
+fix: apply column overrides correctly when using aliased columns in RETURNING clause
+

--- a/packages/generate/src/generate-insert.test.ts
+++ b/packages/generate/src/generate-insert.test.ts
@@ -493,4 +493,18 @@ describe("INSERT validation", () => {
       unknownColumns: ["col"],
     });
   });
+
+  test("INSERT with column override and aliased returning should use custom type", async () => {
+    await testQuery({
+      options: {
+        overrides: {
+          columns: { "test_tbl.col": "CustomType" },
+        },
+      },
+      schema: `CREATE TABLE test_tbl (col TEXT NOT NULL);`,
+      query: `INSERT INTO test_tbl (col) VALUES ('val') RETURNING col AS aliased_col`,
+      expected: [["aliased_col", { kind: "type", value: "CustomType", type: "text" }]],
+      unknownColumns: ["aliased_col"],
+    });
+  });
 });

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -481,7 +481,7 @@ function getResolvedTargetEntry(params: {
 
     const columnOverride = params?.context?.overrides?.columns
       .get(params.col.introspected?.tableName ?? "")
-      ?.get(params.col.described.name);
+      ?.get(params.col.introspected?.colName ?? params.col.described.name);
 
     if (columnOverride !== undefined) {
       return { kind: "type", value: columnOverride, type: pgType.name } satisfies ResolvedTarget;


### PR DESCRIPTION
Fixes an issue where column overrides were not applied correctly when using aliased columns in the RETURNING clause of an INSERT statement. The fix ensures that the correct column name is used to look up overrides, supporting custom types for aliased returning columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where column type overrides were not being applied correctly when using aliased columns in RETURNING clauses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->