### PR TITLE
fix: project option breaks lint for people using projectService option

### DIFF
--- a/packages/eslint-plugin/src/config.ts
+++ b/packages/eslint-plugin/src/config.ts
@@ -14,9 +14,6 @@ export default {
       rules: {
         "@ts-safeql/check-sql": ["error", { useConfigFile: true }],
       },
-      languageOptions: {
-        parserOptions: { project: true },
-      },
     } satisfies FlatConfig.Config,
 
     /**
@@ -28,9 +25,6 @@ export default {
       },
       rules: {
         "@ts-safeql/check-sql": ["error", { connections }],
-      },
-      languageOptions: {
-        parserOptions: { project: true },
       },
     }),
   },


### PR DESCRIPTION
I believe this should fix the problem described in: https://github.com/ts-safeql/safeql/issues/432
These changes fixed it for our projects. 

If there is anything more I should do to help these changes get merged please do tell me. 

Thank you, for your work on safeql :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified ESLint configuration by removing the requirement to load a TypeScript project configuration for type-aware linting in specific configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->