### PR TITLE
feat: Support unnest function for array expansion in type inference

### DIFF
--- a/.changeset/slimy-walls-prove.md
+++ b/.changeset/slimy-walls-prove.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": minor
+---
+
+Added support for `unnest` function in type inference. This allows correct typing when expanding arrays into rows, including support for multidimensional arrays and enums.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* UNNEST function now provides proper type inference when expanding arrays into rows, with support for standard arrays, multidimensional arrays, enum arrays, and nullable array types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->