### PR TITLE
fix: bundle private packages and resolve CJS types

### DIFF
--- a/.changeset/bundle-private-packages.md
+++ b/.changeset/bundle-private-packages.md
@@ -1,0 +1,8 @@
+---
+"@ts-safeql/eslint-plugin": minor
+"@ts-safeql/generate": minor
+---
+
+Smaller install: removed several `@ts-safeql/*` packages from runtime dependencies and inlined them into the published bundle.
+
+If you use `@ts-safeql/generate` directly, install `libpg-query` alongside it — it's now a peer dependency.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,14 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [
-    [
-      "@ts-safeql/eslint-plugin",
-      "@ts-safeql/generate",
-      "@ts-safeql/shared",
-      "@ts-safeql/sql-ast"
-    ]
-  ],
+  "fixed": [["@ts-safeql/eslint-plugin", "@ts-safeql/generate"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/fix-types-for-cjs.md
+++ b/.changeset/fix-types-for-cjs.md
@@ -1,0 +1,9 @@
+---
+"@ts-safeql/generate": patch
+"@ts-safeql/plugin-utils": patch
+"@ts-safeql/zod-annotator": patch
+"@ts-safeql/sql-tag": patch
+"@ts-safeql/plugin-auth-aws": patch
+---
+
+Fix TypeScript types failing to resolve in CommonJS projects.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 generated
 .env
 .env.local
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "test": "turbo run test",
     "lint": "turbo run lint",
     "lint!": "turbo run lint!",
+    "publint": "turbo run publint",
     "dev": "pnpm run --parallel --filter './packages/**' dev",
     "format": "prettier --check '**/*.ts'",
     "format!": "prettier --write '**/*.ts'",
     "clean": "pnpm run --parallel --filter './packages/**' clean",
-    "release": "pnpm build --filter='./packages/*' -- --declaration && changeset publish",
+    "release": "pnpm build --filter='./packages/*' -- --declaration && pnpm publint && changeset publish",
     "version": "changeset version && pnpm i --frozen-lockfile=false",
     "setup": "pnpm run --parallel setup"
   },

--- a/packages/ast-types/package.json
+++ b/packages/ast-types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-safeql/sql-ast",
   "version": "5.0.0",
+  "private": true,
   "license": "MIT",
   "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/eslint-plugin",
   "files": [

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -2,7 +2,11 @@
   "name": "@ts-safeql/eslint-plugin",
   "version": "5.0.0",
   "license": "MIT",
-  "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/eslint-plugin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/eslint-plugin"
+  },
   "files": [
     "dist",
     "package.json"
@@ -45,10 +49,12 @@
     "test": "vitest --pool=forks --hideSkippedTests=true",
     "lint": "eslint src",
     "lint!": "eslint src --fix",
+    "publint": "publint",
     "typecheck": "tsc -b",
     "clean": "rm -rf dist"
   },
   "devDependencies": {
+    "@ts-safeql/connection-manager": "workspace:*",
     "@ts-safeql/generate": "workspace:*",
     "@ts-safeql/shared": "workspace:*",
     "@ts-safeql/sql-ast": "workspace:*",
@@ -59,12 +65,12 @@
     "@typescript-eslint/rule-tester": "catalog:",
     "eslint": "catalog:",
     "libpg-query": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@ts-safeql/connection-manager": "workspace:*",
     "@ts-safeql/plugin-utils": "workspace:*",
     "chokidar": "^4.0.3",
     "fp-ts": "^2.16.9",

--- a/packages/eslint-plugin/src/errors.ts
+++ b/packages/eslint-plugin/src/errors.ts
@@ -1,0 +1,24 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+
+export class InvalidQueryError extends Error {
+  _tag = "InvalidQueryError" as const;
+
+  node: TSESTree.Expression;
+
+  constructor(error: string, node: TSESTree.Expression) {
+    super(error);
+    this.node = node;
+  }
+
+  static of(error: string, node: TSESTree.Expression) {
+    return new InvalidQueryError(error, node);
+  }
+
+  toJSON() {
+    return {
+      _tag: this._tag,
+      message: this.message,
+      node: this.node,
+    };
+  }
+}

--- a/packages/eslint-plugin/src/rules/check-sql.utils.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.utils.ts
@@ -4,11 +4,11 @@ import {
   InvalidConfigError,
   InvalidMigrationError,
   InvalidMigrationsPathError,
-  InvalidQueryError,
   PostgresError,
   QuerySourceMapEntry,
   fmap,
 } from "@ts-safeql/shared";
+import { InvalidQueryError } from "../errors";
 import { TSESTree } from "@typescript-eslint/utils";
 import { RuleFixer, SourceCode } from "@typescript-eslint/utils/ts-eslint";
 import crypto from "crypto";

--- a/packages/eslint-plugin/src/utils/ts-pg.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts-pg.utils.ts
@@ -1,10 +1,10 @@
 import {
   defaultTypeMapping,
   doesMatchPattern,
-  InvalidQueryError,
   normalizeIndent,
   QuerySourceMapEntry,
 } from "@ts-safeql/shared";
+import { InvalidQueryError } from "../errors";
 import { TSESTreeToTSNode } from "@typescript-eslint/typescript-estree";
 import { ParserServices, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import ts, { TypeChecker } from "typescript";

--- a/packages/generate/build.config.ts
+++ b/packages/generate/build.config.ts
@@ -9,6 +9,6 @@ export default defineBuildConfig([
       emitCJS: true,
       inlineDependencies: true,
     },
-    externals: ["libpg-query", "@typescript-eslint/utils"],
+    externals: ["libpg-query"],
   },
 ]);

--- a/packages/generate/build.config.ts
+++ b/packages/generate/build.config.ts
@@ -9,6 +9,6 @@ export default defineBuildConfig([
       emitCJS: true,
       inlineDependencies: true,
     },
-    externals: ["libpg-query"],
+    externals: ["libpg-query", "@typescript-eslint/utils"],
   },
 ]);

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -3,7 +3,11 @@
   "version": "5.0.0",
   "description": "",
   "license": "MIT",
-  "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/eslint-plugin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/generate"
+  },
   "files": [
     "dist",
     "package.json"
@@ -14,7 +18,11 @@
   "main": "dist/index.cjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts",
+        "default": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }
@@ -26,26 +34,31 @@
     "test": "vitest --pool=forks",
     "lint": "eslint src",
     "lint!": "eslint src --fix",
+    "publint": "publint",
     "typecheck": "tsc -b",
     "clean": "rm -rf dist"
   },
   "devDependencies": {
+    "@ts-safeql/shared": "workspace:*",
+    "@ts-safeql/sql-ast": "workspace:*",
+    "@ts-safeql/test-utils": "workspace:*",
     "@types/node": "catalog:",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "eslint": "catalog:",
     "libpg-query": "catalog:",
+    "publint": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@ts-safeql/shared": "workspace:*",
-    "@ts-safeql/sql-ast": "workspace:*",
-    "@ts-safeql/test-utils": "workspace:*",
     "fp-ts": "^2.16.9",
     "pg-connection-string": "^2.7.0",
     "postgres": "catalog:"
+  },
+  "peerDependencies": {
+    "libpg-query": ">=13.2.5"
   }
 }

--- a/packages/plugin-utils/package.json
+++ b/packages/plugin-utils/package.json
@@ -2,7 +2,11 @@
   "name": "@ts-safeql/plugin-utils",
   "version": "5.0.0",
   "license": "MIT",
-  "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/plugin-utils",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/plugin-utils"
+  },
   "files": [
     "dist",
     "package.json"
@@ -13,12 +17,20 @@
   "main": "dist/index.cjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts",
+        "default": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./testing": {
-      "types": "./dist/plugin-test-driver.d.ts",
+      "types": {
+        "import": "./dist/plugin-test-driver.d.mts",
+        "require": "./dist/plugin-test-driver.d.cts",
+        "default": "./dist/plugin-test-driver.d.ts"
+      },
       "import": "./dist/plugin-test-driver.mjs",
       "require": "./dist/plugin-test-driver.cjs"
     }
@@ -26,6 +38,7 @@
   "scripts": {
     "build": "unbuild",
     "dev": "unbuild --stub",
+    "publint": "publint",
     "typecheck": "tsc -b",
     "clean": "rm -rf dist"
   },
@@ -33,6 +46,7 @@
     "@types/node": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "@typescript-eslint/utils": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:"
   },

--- a/packages/plugins/auth-aws/package.json
+++ b/packages/plugins/auth-aws/package.json
@@ -2,7 +2,11 @@
   "name": "@ts-safeql/plugin-auth-aws",
   "version": "4.3.0",
   "license": "MIT",
-  "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/plugins/auth-aws",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/plugins/auth-aws"
+  },
   "files": [
     "dist",
     "package.json"
@@ -13,7 +17,11 @@
   "main": "dist/index.cjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts",
+        "default": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }
@@ -21,12 +29,14 @@
   "scripts": {
     "build": "unbuild",
     "dev": "unbuild --stub",
+    "publint": "publint",
     "typecheck": "tsc -b",
     "test": "vitest --run",
     "clean": "rm -rf dist"
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-safeql/shared",
   "version": "5.0.0",
+  "private": true,
   "license": "MIT",
   "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/eslint-plugin",
   "files": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -38,7 +38,6 @@
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "catalog:",
     "minimatch": "^10.0.1",
     "postgres": "catalog:"
   }

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import type { TSESTree } from "@typescript-eslint/utils";
 import postgres from "postgres";
 
 export class DatabaseInitializationError extends Error {
@@ -102,29 +101,6 @@ export class InvalidMigrationError extends Error {
       _tag: this._tag,
       filePath: this.filePath,
       message: this.message,
-    };
-  }
-}
-
-export class InvalidQueryError extends Error {
-  _tag = "InvalidQueryError" as const;
-
-  node: TSESTree.Expression;
-
-  constructor(error: string, node: TSESTree.Expression) {
-    super(error);
-    this.node = node;
-  }
-
-  static of(error: string, node: TSESTree.Expression) {
-    return new InvalidQueryError(error, node);
-  }
-
-  toJSON() {
-    return {
-      _tag: this._tag,
-      message: this.message,
-      node: this.node,
     };
   }
 }

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/utils";
 import postgres from "postgres";
 
 export class DatabaseInitializationError extends Error {

--- a/packages/sql-tag/package.json
+++ b/packages/sql-tag/package.json
@@ -3,7 +3,11 @@
   "version": "0.2.1",
   "description": "",
   "license": "MIT",
-  "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/eslint-plugin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/sql-tag"
+  },
   "files": [
     "dist",
     "package.json"
@@ -29,6 +33,7 @@
     "test": "vitest",
     "lint": "eslint src",
     "lint!": "eslint src --fix",
+    "publint": "publint",
     "typecheck": "tsc -b",
     "clean": "rm -rf dist"
   },
@@ -37,6 +42,7 @@
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "eslint": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-safeql/test-utils",
   "version": "0.0.61",
+  "private": true,
   "license": "MIT",
   "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/eslint-plugin",
   "files": [

--- a/packages/zod-annotator/package.json
+++ b/packages/zod-annotator/package.json
@@ -3,7 +3,11 @@
   "version": "5.0.0",
   "description": "Zod schema annotator for SafeQL plugins",
   "license": "MIT",
-  "repository": "https://github.com/ts-safeql/safeql/tree/master/packages/zod-annotator",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/zod-annotator"
+  },
   "files": [
     "dist",
     "package.json"
@@ -14,7 +18,11 @@
   "main": "dist/index.cjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts",
+        "default": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }
@@ -23,6 +31,7 @@
     "build": "unbuild",
     "dev": "unbuild --stub",
     "test": "vitest --run",
+    "publint": "publint",
     "typecheck": "tsc -b",
     "clean": "rm -rf dist"
   },
@@ -30,6 +39,7 @@
     "@types/node": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "@typescript-eslint/utils": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     prettier:
       specifier: ^3.5.3
       version: 3.5.3
+    publint:
+      specifier: ^0.3.18
+      version: 0.3.18
     tsx:
       specifier: ^4.19.3
       version: 4.19.3
@@ -635,9 +638,6 @@ importers:
 
   packages/eslint-plugin:
     dependencies:
-      '@ts-safeql/connection-manager':
-        specifier: workspace:*
-        version: link:../connection-manager
       '@ts-safeql/plugin-utils':
         specifier: workspace:*
         version: link:../plugin-utils
@@ -672,6 +672,9 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
     devDependencies:
+      '@ts-safeql/connection-manager':
+        specifier: workspace:*
+        version: link:../connection-manager
       '@ts-safeql/generate':
         specifier: workspace:*
         version: link:../generate
@@ -702,6 +705,9 @@ importers:
       libpg-query:
         specifier: 'catalog:'
         version: 17.5.2
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.18
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -714,15 +720,6 @@ importers:
 
   packages/generate:
     dependencies:
-      '@ts-safeql/shared':
-        specifier: workspace:*
-        version: link:../shared
-      '@ts-safeql/sql-ast':
-        specifier: workspace:*
-        version: link:../ast-types
-      '@ts-safeql/test-utils':
-        specifier: workspace:*
-        version: link:../test-utils
       fp-ts:
         specifier: ^2.16.9
         version: 2.16.9
@@ -733,6 +730,15 @@ importers:
         specifier: 'catalog:'
         version: 3.4.7
     devDependencies:
+      '@ts-safeql/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@ts-safeql/sql-ast':
+        specifier: workspace:*
+        version: link:../ast-types
+      '@ts-safeql/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
@@ -748,6 +754,9 @@ importers:
       libpg-query:
         specifier: 'catalog:'
         version: 17.5.2
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.18
       tsx:
         specifier: 'catalog:'
         version: 4.19.3
@@ -776,6 +785,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: 'catalog:'
         version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.18
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -801,6 +813,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.18
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -859,6 +874,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.0.3(jiti@2.4.2)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.18
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -921,6 +939,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: 'catalog:'
         version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.18
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1825,6 +1846,10 @@ packages:
 
   '@prisma/get-platform@6.5.0':
     resolution: {integrity: sha512-xYcvyJwNMg2eDptBYFqFLUCfgi+wZLcj6HDMsj0Qw0irvauG4IKmkbywnqwok0B+k+W+p+jThM2DKTSmoPCkzw==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -3356,6 +3381,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3711,6 +3739,11 @@ packages:
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
 
+  publint@0.3.18:
+    resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3781,6 +3814,10 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -5400,6 +5437,8 @@ snapshots:
   '@prisma/get-platform@6.5.0':
     dependencies:
       '@prisma/debug': 6.5.0
+
+  '@publint/pack@0.1.4': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.37.0)':
     optionalDependencies:
@@ -7093,6 +7132,8 @@ snapshots:
     dependencies:
       quansync: 0.2.10
 
+  package-manager-detector@1.6.0: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.1.3: {}
@@ -7401,6 +7442,13 @@ snapshots:
 
   property-information@7.0.0: {}
 
+  publint@0.3.18:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   punycode@2.3.1: {}
 
   quansync@0.2.10: {}
@@ -7483,6 +7531,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,9 +828,6 @@ importers:
 
   packages/shared:
     dependencies:
-      '@typescript-eslint/utils':
-        specifier: 'catalog:'
-        version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
       minimatch:
         specifier: ^10.0.1
         version: 10.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalog:
   "libpg-query": "^17.5.2"
   "postgres": "^3.4.5"
   "prettier": "^3.5.3"
+  "publint": "^0.3.18"
   "tsx": "^4.19.3"
   "turbo": "^2.4.4"
   "typescript": "^5.8.2"

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,10 @@
       "dependsOn": ["^build"],
       "inputs": ["src/**/*.ts", "test/**/*.ts"]
     },
-    "lint": {}
+    "lint": {},
+    "publint": {
+      "dependsOn": ["build"],
+      "inputs": ["package.json", "dist/**"]
+    }
   }
 }


### PR DESCRIPTION
fixes https://github.com/ts-safeql/safeql/issues/456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript type resolution failures in CommonJS projects across multiple packages.

* **New Features**
  * Improved package bundling with inlined dependencies for smaller distribution sizes.
  * Added publication validation to the release process.

* **Breaking Changes**
  * Direct usage of `@ts-safeql/generate` now requires `libpg-query` to be installed as a peer dependency.

* **Chores**
  * Updated package metadata and repository configurations.
  * Marked internal utility packages as private.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->