### PR TITLE
feat: improve inference for columns from subqueries in join trees

### DIFF
--- a/.changeset/lateral-subselect-jsonb-inference.md
+++ b/.changeset/lateral-subselect-jsonb-inference.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Improve inference for columns selected from subqueries inside join trees.

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -15,6 +15,7 @@ import {
   FlattenedRelationWithJoins,
   flattenRelationsWithJoinsMap,
   getRelationsWithJoins,
+  isRelationNullableDueToJoin,
 } from "./utils/get-relations-with-joins";
 
 type ASTDescriptionOptions = {
@@ -1052,6 +1053,43 @@ function getDescribedJsonBuildObjectFunCall({
   ];
 }
 
+function findRangeSubselectByAlias(params: {
+  fromClause: LibPgQueryAST.Node[] | undefined;
+  alias: string;
+}): LibPgQueryAST.RangeSubselect | undefined {
+  for (const node of params.fromClause ?? []) {
+    const found = findRangeSubselectByAliasInFromNode(node, params.alias);
+
+    if (found !== undefined) {
+      return found;
+    }
+  }
+
+  return undefined;
+}
+
+function findRangeSubselectByAliasInFromNode(
+  node: LibPgQueryAST.Node | undefined,
+  alias: string,
+): LibPgQueryAST.RangeSubselect | undefined {
+  if (node === undefined) {
+    return undefined;
+  }
+
+  if (node.RangeSubselect?.alias?.aliasname === alias) {
+    return node.RangeSubselect;
+  }
+
+  if (node.JoinExpr !== undefined) {
+    return (
+      findRangeSubselectByAliasInFromNode(node.JoinExpr.larg, alias) ??
+      findRangeSubselectByAliasInFromNode(node.JoinExpr.rarg, alias)
+    );
+  }
+
+  return undefined;
+}
+
 function getColumnRefOrigins({
   context,
   node,
@@ -1062,11 +1100,9 @@ function getColumnRefOrigins({
       // lookup in cte
       context.select.withClause?.ctes.find((cte) => cte.CommonTableExpr?.ctename === source)
         ?.CommonTableExpr?.ctequery?.SelectStmt?.targetList ??
-      // lookup in subselect
-      context.select.fromClause
-        ?.map((from) => from.RangeSubselect)
-        .find((subselect) => subselect?.alias?.aliasname === source)?.subquery?.SelectStmt
-        ?.targetList
+      // lookup in subselect (including inside join trees, e.g. LATERAL)
+      findRangeSubselectByAlias({ fromClause: context.select.fromClause, alias: source })?.subquery
+        ?.SelectStmt?.targetList
     );
   }
 
@@ -1081,10 +1117,10 @@ function getColumnRefOrigins({
           (x) => x.ResTarget?.name === column,
         ) ??
       // lookup in subselect
-      context.select.fromClause
-        ?.map((from) => from.RangeSubselect)
-        .find((subselect) => subselect?.alias?.aliasname === source)
-        ?.subquery?.SelectStmt?.targetList?.find((x) => x.ResTarget?.name === column);
+      findRangeSubselectByAlias({
+        fromClause: context.select.fromClause,
+        alias: source,
+      })?.subquery?.SelectStmt?.targetList?.find((x) => x.ResTarget?.name === column);
 
     if (!origin) return undefined;
 
@@ -1113,9 +1149,10 @@ function getContextForColumnRef(
     }
 
     if (source?.kind === "subselect") {
-      const select = context.select.fromClause
-        ?.map((from) => from.RangeSubselect)
-        .find((subselect) => subselect?.alias?.aliasname === sourceName)?.subquery?.SelectStmt;
+      const select = findRangeSubselectByAlias({
+        fromClause: context.select.fromClause,
+        alias: sourceName,
+      })?.subquery?.SelectStmt;
 
       return {
         ...context,
@@ -1128,6 +1165,22 @@ function getContextForColumnRef(
   return context;
 }
 
+function isNullableSubselectColumnRef(
+  context: ASTDescriptionContext,
+  node: LibPgQueryAST.ColumnRef,
+): boolean {
+  if (!isColumnTableColumnRef(node.fields)) {
+    return false;
+  }
+
+  const sourceName = node.fields[0].String.sval;
+
+  return (
+    context.resolver.sources.get(sourceName)?.kind === "subselect" &&
+    isRelationNullableDueToJoin(context.relations, sourceName)
+  );
+}
+
 function getDescribedColumnRef({
   alias,
   context,
@@ -1137,9 +1190,18 @@ function getDescribedColumnRef({
 
   if (definitionNodes) {
     const defContext = getContextForColumnRef(context, node);
-    return definitionNodes.flatMap((node) =>
-      getDescribedNode({ alias, node, context: defContext }),
+    const columns = definitionNodes.flatMap((definitionNode) =>
+      getDescribedNode({ alias, node: definitionNode, context: defContext }),
     );
+
+    if (isNullableSubselectColumnRef(context, node)) {
+      return columns.map((col) => ({
+        ...col,
+        type: resolveType({ context, nullable: true, type: col.type }),
+      }));
+    }
+
+    return columns;
   }
 
   const fromSchema = getDescribedColumnRefFromSchema({ alias, context, node });

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -1169,7 +1169,7 @@ function isNullableSubselectColumnRef(
   context: ASTDescriptionContext,
   node: LibPgQueryAST.ColumnRef,
 ): boolean {
-  if (!isColumnTableColumnRef(node.fields)) {
+  if (!isColumnTableColumnRef(node.fields) && !isColumnTableStarRef(node.fields)) {
     return false;
   }
 

--- a/packages/generate/src/ast-get-sources.ts
+++ b/packages/generate/src/ast-get-sources.ts
@@ -1,7 +1,9 @@
-import { assertNever } from "@ts-safeql/shared";
 import * as LibPgQueryAST from "@ts-safeql/sql-ast";
 import { PgColRow } from "./generate";
-import { FlattenedRelationWithJoins } from "./utils/get-relations-with-joins";
+import {
+  FlattenedRelationWithJoins,
+  isRelationNullableDueToJoin,
+} from "./utils/get-relations-with-joins";
 
 export type SourcesResolver = ReturnType<typeof getSources>;
 
@@ -46,23 +48,6 @@ export function getSources({
   pgColsBySchemaAndTableName,
   relations,
 }: SourcesOptions) {
-  const relationsByAlias = new Map<string, FlattenedRelationWithJoins>();
-  const relationsByRelName = new Map<string, FlattenedRelationWithJoins[]>();
-
-  for (const rel of relations) {
-    const key = rel.alias ?? rel.joinRelName;
-
-    if (key) {
-      relationsByAlias.set(key, rel);
-    }
-
-    if (!relationsByRelName.has(rel.relName)) {
-      relationsByRelName.set(rel.relName, []);
-    }
-
-    relationsByRelName.get(rel.relName)!.push(rel);
-  }
-
   const tableToSchema = new Map<string, string>();
 
   const publicCols = pgColsBySchemaAndTableName.get("public");
@@ -331,7 +316,7 @@ export function getSources({
           if (nested) {
             return {
               ...nested,
-              isNotNull: nested.isNotNull && !checkIsNullableDueToRelation(source.name),
+              isNotNull: nested.isNotNull && !isRelationNullableDueToJoin(relations, source.name),
             };
           }
           break;
@@ -362,12 +347,12 @@ export function getSources({
             case "subselect": {
               const column = source.sources.getNestedResolvedTargetField(field);
               if (column) {
-                // Check if this subselect is part of a LEFT JOIN or FULL JOIN
-                const isNullableDueToRelation = checkIsNullableDueToRelation(source.name);
+                const isNullableDueToRelation = isRelationNullableDueToJoin(relations, source.name);
+
                 if (isNullableDueToRelation && column.isNotNull) {
-                  // Make the column nullable if it's from a left/full joined subselect
                   return [{ ...column, isNotNull: false }];
                 }
+
                 return [column];
               }
               break;
@@ -396,12 +381,12 @@ export function getSources({
             case "subselect": {
               const columns = source.sources.getColumnsByTargetField(field);
               if (columns) {
-                // Check if this subselect is part of a LEFT JOIN or FULL JOIN
-                const isNullableDueToRelation = checkIsNullableDueToRelation(source.name);
+                const isNullableDueToRelation = isRelationNullableDueToJoin(relations, source.name);
+
                 if (isNullableDueToRelation) {
-                  // Make columns nullable if they're from a left/full joined subselect
                   return columns.map((col) => (col.isNotNull ? { ...col, isNotNull: false } : col));
                 }
+
                 return columns;
               }
               break;
@@ -417,52 +402,9 @@ export function getSources({
     }
   }
 
-  function checkIsNullableDueToRelation(key: string): boolean {
-    const rel = relationsByAlias.get(key);
-    if (rel !== undefined) {
-      switch (rel.joinType) {
-        case LibPgQueryAST.JoinType.JOIN_LEFT:
-        case LibPgQueryAST.JoinType.JOIN_FULL:
-          return true;
-        case LibPgQueryAST.JoinType.JOIN_TYPE_UNDEFINED:
-        case LibPgQueryAST.JoinType.JOIN_INNER:
-        case LibPgQueryAST.JoinType.JOIN_RIGHT:
-        case LibPgQueryAST.JoinType.JOIN_SEMI:
-        case LibPgQueryAST.JoinType.JOIN_ANTI:
-        case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
-        case LibPgQueryAST.JoinType.JOIN_UNIQUE_INNER:
-        case LibPgQueryAST.JoinType.UNRECOGNIZED:
-          return false;
-        default:
-          return assertNever(rel.joinType);
-      }
-    }
-
-    for (const relation of relationsByRelName.get(key) ?? []) {
-      switch (relation.joinType) {
-        case LibPgQueryAST.JoinType.JOIN_RIGHT:
-        case LibPgQueryAST.JoinType.JOIN_FULL:
-          return true;
-        case LibPgQueryAST.JoinType.JOIN_TYPE_UNDEFINED:
-        case LibPgQueryAST.JoinType.JOIN_INNER:
-        case LibPgQueryAST.JoinType.JOIN_LEFT:
-        case LibPgQueryAST.JoinType.JOIN_SEMI:
-        case LibPgQueryAST.JoinType.JOIN_ANTI:
-        case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
-        case LibPgQueryAST.JoinType.JOIN_UNIQUE_INNER:
-        case LibPgQueryAST.JoinType.UNRECOGNIZED:
-          return false;
-        default:
-          return assertNever(relation.joinType);
-      }
-    }
-
-    return false;
-  }
-
   function resolveColumn(col: PgColRow, source: TableSelectSource): ResolvedColumn {
     const keyForNullability = source.alias ? source.alias : source.original;
-    const isNullableDueToRelation = checkIsNullableDueToRelation(keyForNullability);
+    const isNullableDueToRelation = isRelationNullableDueToJoin(relations, keyForNullability);
     const isNotNullBasedOnAST =
       nonNullableColumns.has(col.colName) ||
       nonNullableColumns.has(`${source.name}.${col.colName}`);

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -2537,6 +2537,66 @@ test("select jsonb_build_object from LEFT JOIN LATERAL should return nullable ob
   });
 });
 
+test("select star from LEFT JOIN LATERAL should return nullable object", async () => {
+  await testQuery({
+    schema: `
+      CREATE TABLE invoice (id INTEGER PRIMARY KEY, customer_id INTEGER NOT NULL);
+      CREATE TABLE customer (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+    `,
+    query: `
+      SELECT cust_json.*
+      FROM invoice inv
+      LEFT JOIN LATERAL (
+        SELECT jsonb_build_object('name', c.name) AS snapshot
+        FROM customer c
+        WHERE c.id = inv.customer_id
+      ) cust_json ON TRUE
+    `,
+    expected: [
+      [
+        "snapshot",
+        {
+          kind: "union",
+          value: [
+            { kind: "object", value: [["name", { kind: "type", value: "string", type: "text" }]] },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("select nullable column from LEFT JOIN LATERAL should return flat nullable type", async () => {
+  await testQuery({
+    schema: `
+      CREATE TABLE invoice (id INTEGER PRIMARY KEY, customer_id INTEGER NOT NULL);
+      CREATE TABLE customer (id INTEGER PRIMARY KEY, nickname TEXT);
+    `,
+    query: `
+      SELECT cust_json.snapshot
+      FROM invoice inv
+      LEFT JOIN LATERAL (
+        SELECT c.nickname AS snapshot
+        FROM customer c
+        WHERE c.id = inv.customer_id
+      ) cust_json ON TRUE
+    `,
+    expected: [
+      [
+        "snapshot",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "text" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
 test("select jsonb_build_object from INNER JOIN LATERAL should return object", async () => {
   await testQuery({
     schema: `

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -2507,6 +2507,60 @@ test("select from LEFT JOIN LATERAL should return nullable field", async () => {
   });
 });
 
+test("select jsonb_build_object from LEFT JOIN LATERAL should return nullable object", async () => {
+  await testQuery({
+    schema: `
+      CREATE TABLE invoice (id INTEGER PRIMARY KEY, customer_id INTEGER NOT NULL);
+      CREATE TABLE customer (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+    `,
+    query: `
+      SELECT cust_json.snapshot
+      FROM invoice inv
+      LEFT JOIN LATERAL (
+        SELECT jsonb_build_object('name', c.name) AS snapshot
+        FROM customer c
+        WHERE c.id = inv.customer_id
+      ) cust_json ON TRUE
+    `,
+    expected: [
+      [
+        "snapshot",
+        {
+          kind: "union",
+          value: [
+            { kind: "object", value: [["name", { kind: "type", value: "string", type: "text" }]] },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("select jsonb_build_object from INNER JOIN LATERAL should return object", async () => {
+  await testQuery({
+    schema: `
+      CREATE TABLE invoice (id INTEGER PRIMARY KEY, customer_id INTEGER NOT NULL);
+      CREATE TABLE customer (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+    `,
+    query: `
+      SELECT cust_json.snapshot
+      FROM invoice inv
+      INNER JOIN LATERAL (
+        SELECT jsonb_build_object('name', c.name) AS snapshot
+        FROM customer c
+        WHERE c.id = inv.customer_id
+      ) cust_json ON TRUE
+    `,
+    expected: [
+      [
+        "snapshot",
+        { kind: "object", value: [["name", { kind: "type", value: "string", type: "text" }]] },
+      ],
+    ],
+  });
+});
+
 test("nullable columns in regular subselect should remain nullable", async () => {
   await testQuery({
     schema: `

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -1,5 +1,4 @@
 import {
-  assertNever,
   defaultTypesMap,
   DuplicateColumnsError,
   getOrSetFromMapWithEnabled,
@@ -10,13 +9,15 @@ import {
   QuerySourceMapEntry,
   toCase,
 } from "@ts-safeql/shared";
-import * as LibPgQueryAST from "@ts-safeql/sql-ast";
 import { either } from "fp-ts";
 import * as parser from "libpg-query";
 import postgres from "postgres";
 import { ASTDescribedColumn, getASTDescription } from "./ast-describe";
 import { ColType } from "./utils/colTypes";
-import { FlattenedRelationWithJoins } from "./utils/get-relations-with-joins";
+import {
+  FlattenedRelationWithJoins,
+  isTableNullableDueToJoin,
+} from "./utils/get-relations-with-joins";
 import { isParsedInsertResult, validateInsertResult } from "./utils/validate-insert";
 
 type JSToPostgresTypeMap = Record<string, unknown>;
@@ -394,57 +395,6 @@ function buildInterfacePropertyValue(params: {
   ];
 }
 
-function checkIsNullableDueToRelation(params: {
-  col: PgColRow;
-  relationsWithJoins: FlattenedRelationWithJoins[];
-}) {
-  const { col, relationsWithJoins } = params;
-
-  const findByJoin = relationsWithJoins.find((x) => x.joinRelName === col.tableName);
-
-  if (findByJoin !== undefined) {
-    switch (findByJoin.joinType) {
-      case LibPgQueryAST.JoinType.JOIN_LEFT:
-      case LibPgQueryAST.JoinType.JOIN_FULL:
-        return true;
-      case LibPgQueryAST.JoinType.JOIN_TYPE_UNDEFINED:
-      case LibPgQueryAST.JoinType.JOIN_INNER:
-      case LibPgQueryAST.JoinType.JOIN_RIGHT:
-      case LibPgQueryAST.JoinType.JOIN_SEMI:
-      case LibPgQueryAST.JoinType.JOIN_ANTI:
-      case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
-      case LibPgQueryAST.JoinType.JOIN_UNIQUE_INNER:
-      case LibPgQueryAST.JoinType.UNRECOGNIZED:
-        return false;
-      default:
-        assertNever(findByJoin.joinType);
-    }
-  }
-
-  const findByRel = relationsWithJoins.filter((x) => x.relName === col.tableName);
-
-  for (const rel of findByRel) {
-    switch (rel.joinType) {
-      case LibPgQueryAST.JoinType.JOIN_RIGHT:
-      case LibPgQueryAST.JoinType.JOIN_FULL:
-        return true;
-      case LibPgQueryAST.JoinType.JOIN_TYPE_UNDEFINED:
-      case LibPgQueryAST.JoinType.JOIN_INNER:
-      case LibPgQueryAST.JoinType.JOIN_LEFT:
-      case LibPgQueryAST.JoinType.JOIN_SEMI:
-      case LibPgQueryAST.JoinType.JOIN_ANTI:
-      case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
-      case LibPgQueryAST.JoinType.JOIN_UNIQUE_INNER:
-      case LibPgQueryAST.JoinType.UNRECOGNIZED:
-        return false;
-      default:
-        assertNever(rel.joinType);
-    }
-  }
-
-  return false;
-}
-
 function getResolvedTargetEntry(params: {
   col: ColumnAnalysisResult;
   context: GenerateContext;
@@ -538,10 +488,7 @@ function getResolvedTargetEntry(params: {
     isNonNullable = params.col.introspected.colNotNull;
 
     if (
-      checkIsNullableDueToRelation({
-        col: params.col.introspected,
-        relationsWithJoins: params.context.relationsWithJoins,
-      })
+      isTableNullableDueToJoin(params.context.relationsWithJoins, params.col.introspected.tableName)
     ) {
       isNonNullable = false;
     }

--- a/packages/generate/src/utils/get-relations-with-joins.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@ts-safeql/shared";
 import * as LibPgQueryAST from "@ts-safeql/sql-ast";
 
 interface Join {
@@ -90,4 +91,79 @@ export function flattenRelationsWithJoinsMap(
   });
 
   return result;
+}
+
+function isNullableJoinedRelation(joinType: LibPgQueryAST.JoinType): boolean {
+  switch (joinType) {
+    case LibPgQueryAST.JoinType.JOIN_LEFT:
+    case LibPgQueryAST.JoinType.JOIN_FULL:
+      return true;
+    case LibPgQueryAST.JoinType.JOIN_TYPE_UNDEFINED:
+    case LibPgQueryAST.JoinType.JOIN_INNER:
+    case LibPgQueryAST.JoinType.JOIN_RIGHT:
+    case LibPgQueryAST.JoinType.JOIN_SEMI:
+    case LibPgQueryAST.JoinType.JOIN_ANTI:
+    case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
+    case LibPgQueryAST.JoinType.JOIN_UNIQUE_INNER:
+    case LibPgQueryAST.JoinType.UNRECOGNIZED:
+      return false;
+    default:
+      return assertNever(joinType);
+  }
+}
+
+function isNullableBaseRelation(joinType: LibPgQueryAST.JoinType): boolean {
+  switch (joinType) {
+    case LibPgQueryAST.JoinType.JOIN_RIGHT:
+    case LibPgQueryAST.JoinType.JOIN_FULL:
+      return true;
+    case LibPgQueryAST.JoinType.JOIN_TYPE_UNDEFINED:
+    case LibPgQueryAST.JoinType.JOIN_INNER:
+    case LibPgQueryAST.JoinType.JOIN_LEFT:
+    case LibPgQueryAST.JoinType.JOIN_SEMI:
+    case LibPgQueryAST.JoinType.JOIN_ANTI:
+    case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
+    case LibPgQueryAST.JoinType.JOIN_UNIQUE_INNER:
+    case LibPgQueryAST.JoinType.UNRECOGNIZED:
+      return false;
+    default:
+      return assertNever(joinType);
+  }
+}
+
+function hasNullableBaseRelation(
+  relations: FlattenedRelationWithJoins[],
+  relationName: string,
+): boolean {
+  return relations.some(
+    (relation) => relation.relName === relationName && isNullableBaseRelation(relation.joinType),
+  );
+}
+
+export function isRelationNullableDueToJoin(
+  relations: FlattenedRelationWithJoins[],
+  relationName: string,
+): boolean {
+  const joinedRelation = relations.find(
+    (relation) => (relation.alias ?? relation.joinRelName) === relationName,
+  );
+
+  if (joinedRelation !== undefined) {
+    return isNullableJoinedRelation(joinedRelation.joinType);
+  }
+
+  return hasNullableBaseRelation(relations, relationName);
+}
+
+export function isTableNullableDueToJoin(
+  relations: FlattenedRelationWithJoins[],
+  tableName: string,
+): boolean {
+  const joinedRelation = relations.find((relation) => relation.joinRelName === tableName);
+
+  if (joinedRelation !== undefined) {
+    return isNullableJoinedRelation(joinedRelation.joinType);
+  }
+
+  return hasNullableBaseRelation(relations, tableName);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for columns selected from subqueries inside joins, including correct nullability for LATERAL and other join patterns.
  * Better resolution of column origins across complex nested join/subquery structures.

* **Tests**
  * Added tests covering nullability inference for LATERAL join scenarios.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->