### PR TITLE
feat: track non-nullable columns through join conditions and subqueries

### DIFF
--- a/.changeset/view-inner-join-nullability.md
+++ b/.changeset/view-inner-join-nullability.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Infer columns selected from views as non-null when equality predicates guarantee their presence.

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -2637,6 +2637,21 @@ test("select inner joined view column inside subselect should remain non-nullabl
   });
 });
 
+test("select aliased inner joined view column from subselect should remain non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW visible_caregiver AS SELECT id FROM caregiver`,
+    query: `
+      SELECT subquery.caregiver_id AS cid
+      FROM (
+        SELECT visible_caregiver.id AS caregiver_id
+        FROM caregiver_agency
+          JOIN visible_caregiver ON visible_caregiver.id = caregiver_agency.caregiver_id
+      ) subquery
+    `,
+    expected: [["cid", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
 test("select inner joined view column inside JOIN LATERAL should remain non-nullable", async () => {
   await testQuery({
     schema: `CREATE VIEW visible_caregiver AS SELECT id FROM caregiver`,

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -2597,6 +2597,63 @@ test("select nullable column from LEFT JOIN LATERAL should return flat nullable 
   });
 });
 
+test("select inner joined view column should remain non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW visible_caregiver AS SELECT id FROM caregiver`,
+    query: `
+      SELECT visible_caregiver.id AS caregiver_id
+      FROM caregiver_agency
+        JOIN visible_caregiver ON visible_caregiver.id = caregiver_agency.caregiver_id
+    `,
+    expected: [["caregiver_id", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
+test("select view column joined through left joined column should remain non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW visible_caregiver AS SELECT id FROM caregiver`,
+    query: `
+      SELECT visible_caregiver.id AS caregiver_id
+      FROM caregiver
+        LEFT JOIN caregiver_agency ON caregiver_agency.caregiver_id = caregiver.id
+        JOIN visible_caregiver ON visible_caregiver.id = caregiver_agency.caregiver_id
+    `,
+    expected: [["caregiver_id", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
+test("select inner joined view column inside subselect should remain non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW visible_caregiver AS SELECT id FROM caregiver`,
+    query: `
+      SELECT subquery.caregiver_id
+      FROM (
+        SELECT visible_caregiver.id AS caregiver_id
+        FROM caregiver_agency
+          JOIN visible_caregiver ON visible_caregiver.id = caregiver_agency.caregiver_id
+      ) subquery
+    `,
+    expected: [["caregiver_id", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
+test("select inner joined view column inside JOIN LATERAL should remain non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW visible_caregiver AS SELECT id FROM caregiver`,
+    query: `
+      SELECT caregiver_lookup.caregiver_id
+      FROM caregiver_agency
+        JOIN LATERAL (
+          SELECT visible_caregiver.id AS caregiver_id
+          FROM visible_caregiver
+          WHERE visible_caregiver.id = caregiver_agency.caregiver_id
+          LIMIT 1
+        ) caregiver_lookup ON TRUE
+    `,
+    expected: [["caregiver_id", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
 test("select jsonb_build_object from INNER JOIN LATERAL should return object", async () => {
   await testQuery({
     schema: `

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -265,6 +265,145 @@ function getTargetName(target: LibPgQueryAST.ResTarget): string {
   return target.name ?? getNodeName(target.val);
 }
 
+function addColumnRef(nonNullableColumns: Set<string>, node: LibPgQueryAST.Node | undefined) {
+  if (node?.ColumnRef?.fields !== undefined) {
+    nonNullableColumns.add(concatStringNodes(node.ColumnRef.fields));
+  }
+}
+
+function addColumnRefsFromEqualityExpr(
+  nonNullableColumns: Set<string>,
+  node: LibPgQueryAST.Node | undefined,
+) {
+  if (node?.BoolExpr?.boolop === LibPgQueryAST.BoolExprType.AND_EXPR) {
+    for (const arg of node.BoolExpr.args) {
+      addColumnRefsFromEqualityExpr(nonNullableColumns, arg);
+    }
+  }
+
+  if (node?.A_Expr?.kind !== LibPgQueryAST.AExprKind.AEXPR_OP) {
+    return;
+  }
+
+  if (concatStringNodes(node.A_Expr.name) !== "=") {
+    return;
+  }
+
+  addColumnRef(nonNullableColumns, node.A_Expr.lexpr);
+  addColumnRef(nonNullableColumns, node.A_Expr.rexpr);
+}
+
+function addNonNullableColumnsFromSubselect(
+  nonNullableColumns: Set<string>,
+  node: LibPgQueryAST.Node,
+  root: LibPgQueryAST.ParseResult,
+) {
+  const select = node.RangeSubselect?.subquery?.SelectStmt;
+
+  if (select === undefined) {
+    return;
+  }
+
+  for (const name of getNonNullableColumnsInSelectStmt(select, root)) {
+    nonNullableColumns.add(name);
+  }
+}
+
+function addNonNullableColumnsFromFromNode(
+  nonNullableColumns: Set<string>,
+  node: LibPgQueryAST.Node,
+  root: LibPgQueryAST.ParseResult,
+  isNullable: boolean,
+) {
+  if (!isNullable) {
+    addNonNullableColumnsFromSubselect(nonNullableColumns, node, root);
+  }
+
+  const joinExpr = node.JoinExpr;
+
+  if (joinExpr === undefined) {
+    return;
+  }
+
+  switch (joinExpr.jointype) {
+    case LibPgQueryAST.JoinType.JOIN_TYPE_UNDEFINED:
+    case LibPgQueryAST.JoinType.JOIN_INNER:
+    case LibPgQueryAST.JoinType.JOIN_SEMI:
+    case LibPgQueryAST.JoinType.JOIN_UNIQUE_INNER:
+      if (!isNullable) {
+        addColumnRefsFromEqualityExpr(nonNullableColumns, joinExpr.quals);
+      }
+
+      if (joinExpr.larg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, isNullable);
+      }
+
+      if (joinExpr.rarg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, isNullable);
+      }
+
+      break;
+
+    case LibPgQueryAST.JoinType.JOIN_LEFT:
+    case LibPgQueryAST.JoinType.JOIN_ANTI:
+    case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
+      if (joinExpr.larg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, isNullable);
+      }
+
+      if (joinExpr.rarg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, true);
+      }
+
+      break;
+
+    case LibPgQueryAST.JoinType.JOIN_RIGHT:
+      if (joinExpr.larg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, true);
+      }
+
+      if (joinExpr.rarg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, isNullable);
+      }
+
+      break;
+
+    case LibPgQueryAST.JoinType.JOIN_FULL:
+    case LibPgQueryAST.JoinType.UNRECOGNIZED:
+      if (joinExpr.larg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, true);
+      }
+
+      if (joinExpr.rarg !== undefined) {
+        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, true);
+      }
+
+      break;
+
+    default:
+      assertNever(joinExpr.jointype);
+  }
+}
+
+function addNonNullableTargetAliases(
+  nonNullableColumns: Set<string>,
+  targetList: LibPgQueryAST.Node[],
+) {
+  for (const target of targetList) {
+    const colRef = target.ResTarget?.val?.ColumnRef;
+
+    if (colRef?.fields === undefined || target.ResTarget === undefined) {
+      continue;
+    }
+
+    const columnName = concatStringNodes(colRef.fields);
+
+    if (nonNullableColumns.has(columnName)) {
+      nonNullableColumns.add(getTargetName(target.ResTarget));
+    }
+  }
+}
+
 function getNonNullableColumnsInSelectStmt(
   stmt: LibPgQueryAST.SelectStmt,
   root: LibPgQueryAST.ParseResult,
@@ -317,7 +456,15 @@ function getNonNullableColumnsInSelectStmt(
         }
       }
     }
+
+    addColumnRefsFromEqualityExpr(nonNullableColumns, stmt.whereClause);
   }
+
+  for (const from of stmt.fromClause ?? []) {
+    addNonNullableColumnsFromFromNode(nonNullableColumns, from, root, false);
+  }
+
+  addNonNullableTargetAliases(nonNullableColumns, targetList);
 
   return nonNullableColumns;
 }

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -279,6 +279,7 @@ function addColumnRefsFromEqualityExpr(
     for (const arg of node.BoolExpr.args) {
       addColumnRefsFromEqualityExpr(nonNullableColumns, arg);
     }
+    return;
   }
 
   if (node?.A_Expr?.kind !== LibPgQueryAST.AExprKind.AEXPR_OP) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for columns selected from views so columns become non-null when equality predicates or inner-join patterns guarantee their presence.

* **Tests**
  * Added comprehensive tests covering inner joins, nested/derived-table joins, lateral joins, and propagation of non-nullability through aliases and subselects.

* **Chores**
  * Added a changeset note to document the non-nullability inference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->