### PR TITLE
fix: improve scalar subquery nullability inference

### DIFF
--- a/.changeset/scalar-subquery-nullability.md
+++ b/.changeset/scalar-subquery-nullability.md
@@ -2,4 +2,4 @@
 "@ts-safeql/generate": patch
 ---
 
-Fix inferred TypeScript return types for scalar subqueries when the inner select always returns one row (e.g. `count()` without `GROUP BY` → `number` instead of `number | null`). Detect aggregates via `pg_proc.prokind`. Also fix inference for empty array literals, typed array casts, and joins with set-returning functions.
+Fix inferred TypeScript return types for scalar subqueries when the inner select always returns one row (e.g. `count(*)` without `GROUP BY` → `string` instead of `string | null` for int8). Detect aggregates from the database catalog. Also fix inference for empty array literals, typed array casts, and joins with set-returning functions.

--- a/.changeset/scalar-subquery-nullability.md
+++ b/.changeset/scalar-subquery-nullability.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Fix inferred TypeScript return types for scalar subqueries when the inner select always returns one row (e.g. `count()` without `GROUP BY` → `number` instead of `number | null`). Detect aggregates via `pg_proc.prokind`. Also fix inference for empty array literals, typed array casts, and joins with set-returning functions.

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -10,11 +10,7 @@ import {
 } from "./ast-decribe.utils";
 import { ResolvedColumn, SourcesResolver, getSources } from "./ast-get-sources";
 import { PgColRow, PgEnumsMaps, PgTypesMap } from "./generate";
-import {
-  getNonNullableColumns,
-  getOutputColumnKey,
-  unwrapNullableUnionType,
-} from "./utils/get-nonnullable-columns";
+import { getNonNullableColumns, getOutputColumnKey } from "./utils/get-nonnullable-columns";
 import {
   FlattenedRelationWithJoins,
   flattenRelationsWithJoinsMap,
@@ -891,6 +887,25 @@ const pgFnArgAliases: Record<string, string> = {
   float4: "real",
   float8: "double precision",
 };
+
+function unwrapNullableUnionType(
+  type: ASTDescribedColumnType,
+): Extract<ASTDescribedColumnType, { kind: "type" }> | undefined {
+  if (type.kind !== "union") {
+    return undefined;
+  }
+
+  const nonNull = type.value.filter(
+    (member): member is Extract<ASTDescribedColumnType, { kind: "type" }> =>
+      member.kind === "type" && member.value !== "null",
+  );
+
+  if (nonNull.length !== 1) {
+    return undefined;
+  }
+
+  return nonNull[0];
+}
 
 function getDescribedFuncCallByPgFn({
   alias,

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -623,12 +623,11 @@ function producesExactlyOneRow(
   select: LibPgQueryAST.SelectStmt,
   aggregateNames: Set<string>,
 ): boolean {
-  if (
-    (select.groupClause?.length ?? 0) > 0 ||
-    select.havingClause !== undefined ||
-    select.limitCount !== undefined ||
-    select.limitOffset !== undefined
-  ) {
+  if ((select.groupClause?.length ?? 0) > 0 || select.havingClause !== undefined) {
+    return false;
+  }
+
+  if (select.limitOffset !== undefined) {
     return false;
   }
 
@@ -644,8 +643,23 @@ function producesExactlyOneRow(
     return false;
   }
 
+  const isAggregateTarget = containsAggregate(target, aggregateNames);
+
+  if (!isAggregateTarget && select.limitCount !== undefined) {
+    return false;
+  }
+
+  if (isAggregateTarget) {
+    return true;
+  }
+
+  const hasFromClause = (select.fromClause?.length ?? 0) > 0;
+
+  if (hasFromClause || select.whereClause !== undefined) {
+    return false;
+  }
+
   return (
-    containsAggregate(target, aggregateNames) ||
     isConstantSingleRowExpression(target) ||
     (target.CaseExpr !== undefined &&
       caseExprProducesExactlyOneRow(target.CaseExpr, aggregateNames))
@@ -656,10 +670,9 @@ function caseExprProducesExactlyOneRow(
   caseExpr: LibPgQueryAST.CaseExpr,
   aggregateNames: Set<string>,
 ): boolean {
-  const branches = [
-    ...caseExpr.args.map((arg) => arg.CaseWhen?.result),
-    caseExpr.defresult,
-  ].filter((node): node is LibPgQueryAST.Node => node !== undefined);
+  const branches = [...caseExpr.args.map((arg) => arg.CaseWhen?.result), caseExpr.defresult].filter(
+    (node): node is LibPgQueryAST.Node => node !== undefined,
+  );
 
   if (branches.length === 0) {
     return false;
@@ -725,8 +738,10 @@ function containsAggregate(node: LibPgQueryAST.Node, aggregateNames: Set<string>
 
     return node.CaseExpr.args.some(
       (arg) =>
-        arg.CaseWhen?.result !== undefined &&
-        containsAggregate(arg.CaseWhen.result, aggregateNames),
+        (arg.CaseWhen?.expr !== undefined &&
+          containsAggregate(arg.CaseWhen.expr, aggregateNames)) ||
+        (arg.CaseWhen?.result !== undefined &&
+          containsAggregate(arg.CaseWhen.result, aggregateNames)),
     );
   }
 
@@ -1016,26 +1031,39 @@ function getDescribedFuncCallByPgFn({
 }: GetDescribedParamsOf<LibPgQueryAST.FuncCall>): ASTDescribedColumn[] {
   const functionName = node.funcname.at(-1)?.String?.sval;
   const name = alias ?? functionName ?? "?column?";
-  const args = (node.args ?? []).flatMap((node) => {
-    const described = getDescribedNode({ alias: undefined, node, context }).at(0);
+  const argTypes = (node.args ?? []).flatMap((argNode) => {
+    const described = getDescribedNode({ alias: undefined, node: argNode, context }).at(0);
 
     if (described?.type.kind === "type") {
-      return [described.type.value];
+      return [{ ts: described.type.value, pg: described.type.type }];
     }
 
     return [];
   });
+  const args = argTypes.map((arg) => arg.ts);
 
   if (functionName === undefined) {
     return [{ name, type: context.toTypeScriptType({ name: "unknown" }) }];
   }
 
-  const pgFnValue =
+  let pgFnValue =
     args.length === 0
       ? (context.pgFns.get(functionName) ?? context.pgFns.get(`${functionName}(string)`))
       : (context.pgFns.get(`${functionName}(${args.join(", ")})`) ??
         context.pgFns.get(`${functionName}(any)`) ??
         context.pgFns.get(`${functionName}(unknown)`));
+
+  if (
+    pgFnValue !== undefined &&
+    argTypes.length > 0 &&
+    (functionName === "max" || functionName === "min")
+  ) {
+    const argPg = argTypes[0].pg;
+    pgFnValue = {
+      ts: context.typesMap.get(argPg)?.value ?? pgFnValue.ts,
+      pg: argPg,
+    };
+  }
 
   const type = resolveType({
     context: context,
@@ -1583,7 +1611,7 @@ function asNonNullableType(type: ASTDescribedColumnType): ASTDescribedColumnType
         return filtered[0];
       }
 
-      return { kind: "union", value: filtered };
+      return normalizeLiteralUnion({ kind: "union", value: filtered });
     }
     case "type":
       return type.value === "null" ? { kind: "type", value: "unknown", type: "unknown" } : type;

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -10,7 +10,11 @@ import {
 } from "./ast-decribe.utils";
 import { ResolvedColumn, SourcesResolver, getSources } from "./ast-get-sources";
 import { PgColRow, PgEnumsMaps, PgTypesMap } from "./generate";
-import { getNonNullableColumns, getOutputColumnKey } from "./utils/get-nonnullable-columns";
+import {
+  getNonNullableColumns,
+  getOutputColumnKey,
+  unwrapNullableUnionType,
+} from "./utils/get-nonnullable-columns";
 import {
   FlattenedRelationWithJoins,
   flattenRelationsWithJoinsMap,
@@ -72,7 +76,9 @@ export function getASTDescription(params: ASTDescriptionOptions): {
     };
   }
 
-  const nonNullableColumns = getNonNullableColumns(params.parsed);
+  const nonNullableColumns = getNonNullableColumns(params.parsed, {
+    aggregateNames: params.pgAggregateNames,
+  });
   const relations = flattenRelationsWithJoinsMap(getRelationsWithJoins(params.parsed));
 
   function getTypeByOid(oid: number) {
@@ -542,32 +548,6 @@ function getBaseType(type: ASTDescribedColumnType): ASTDescribedColumnType {
   }
 }
 
-function unwrapNullableUnionType(
-  type: ASTDescribedColumnType,
-): ASTDescribedColumnType | undefined {
-  if (type.kind !== "union") {
-    return undefined;
-  }
-
-  const nonNull = type.value.flatMap((member) => {
-    if (member.kind === "type" && member.value === "null") {
-      return [];
-    }
-
-    if (member.kind === "type") {
-      return [member];
-    }
-
-    return [];
-  });
-
-  if (nonNull.length === 0) {
-    return undefined;
-  }
-
-  return isSingleCell(nonNull) ? nonNull[0] : mergeDescribedColumnTypes(nonNull);
-}
-
 function getDescribedBoolExpr({
   alias,
   context,
@@ -612,8 +592,10 @@ function getDescribedSubLink({
   };
 
   const name = getOutputColumnKey(alias, { SubLink: node });
-  const nullable = isExprSubLinkNullable({ node, context, columnKey: name });
   const subLinkType = getSubLinkType();
+  const nullable =
+    node.subLinkType === LibPgQueryAST.SubLinkType.EXPR_SUBLINK &&
+    !context.nonNullableColumns.has(name);
 
   return [
     {
@@ -625,177 +607,6 @@ function getDescribedSubLink({
       }),
     },
   ];
-}
-
-function isExprSubLinkNullable(params: {
-  node: LibPgQueryAST.SubLink;
-  context: ASTDescriptionContext;
-  columnKey: string;
-}): boolean {
-  if (params.node.subLinkType !== LibPgQueryAST.SubLinkType.EXPR_SUBLINK) {
-    return false;
-  }
-
-  const select = params.node.subselect?.SelectStmt;
-
-  if (select === undefined || !producesExactlyOneRow(select, params.context.pgAggregateNames)) {
-    return true;
-  }
-
-  return !params.context.nonNullableColumns.has(params.columnKey);
-}
-
-function producesExactlyOneRow(
-  select: LibPgQueryAST.SelectStmt,
-  aggregateNames: Set<string>,
-): boolean {
-  if ((select.groupClause?.length ?? 0) > 0 || select.havingClause !== undefined) {
-    return false;
-  }
-
-  if (select.limitOffset !== undefined) {
-    return false;
-  }
-
-  const targets = select.targetList ?? [];
-
-  if (targets.length !== 1) {
-    return false;
-  }
-
-  const target = targets[0]?.ResTarget?.val;
-
-  if (target === undefined) {
-    return false;
-  }
-
-  const isAggregateTarget = containsAggregate(target, aggregateNames);
-
-  if (!isAggregateTarget && select.limitCount !== undefined) {
-    return false;
-  }
-
-  if (isAggregateTarget) {
-    return select.limitCount === undefined || isPositiveLimitCount(select.limitCount);
-  }
-
-  const hasFromClause = (select.fromClause?.length ?? 0) > 0;
-
-  if (hasFromClause || select.whereClause !== undefined) {
-    return false;
-  }
-
-  return (
-    isConstantSingleRowExpression(target) ||
-    (target.CaseExpr !== undefined &&
-      caseExprProducesExactlyOneRow(target.CaseExpr, aggregateNames))
-  );
-}
-
-function caseExprProducesExactlyOneRow(
-  caseExpr: LibPgQueryAST.CaseExpr,
-  aggregateNames: Set<string>,
-): boolean {
-  if (caseExpr.defresult === undefined) {
-    return false;
-  }
-
-  const branches = [...caseExpr.args.map((arg) => arg.CaseWhen?.result), caseExpr.defresult].filter(
-    (node): node is LibPgQueryAST.Node => node !== undefined,
-  );
-
-  if (branches.length === 0) {
-    return false;
-  }
-
-  return branches.every(
-    (branch) => containsAggregate(branch, aggregateNames) || isConstantSingleRowExpression(branch),
-  );
-}
-
-function isConstantSingleRowExpression(node: LibPgQueryAST.Node): boolean {
-  if (node.A_Const !== undefined) {
-    return node.A_Const.isnull !== true;
-  }
-
-  if (node.TypeCast?.arg !== undefined) {
-    return isConstantSingleRowExpression(node.TypeCast.arg);
-  }
-
-  if (node.A_Expr !== undefined) {
-    const { lexpr, rexpr } = node.A_Expr;
-    return (
-      (lexpr === undefined || isConstantSingleRowExpression(lexpr)) &&
-      (rexpr === undefined || isConstantSingleRowExpression(rexpr))
-    );
-  }
-
-  return false;
-}
-
-function isPositiveLimitCount(limitCount: LibPgQueryAST.Node): boolean {
-  const value = getConstantIntegerValue(limitCount);
-
-  return value !== undefined && value > 0;
-}
-
-function getConstantIntegerValue(node: LibPgQueryAST.Node): number | undefined {
-  if (node.A_Const?.ival !== undefined) {
-    const ival = node.A_Const.ival;
-
-    return typeof ival === "number" ? ival : ival.ival;
-  }
-
-  if (node.TypeCast?.arg !== undefined) {
-    return getConstantIntegerValue(node.TypeCast.arg);
-  }
-
-  return undefined;
-}
-
-function containsAggregate(node: LibPgQueryAST.Node, aggregateNames: Set<string>): boolean {
-  if (node.TypeCast?.arg !== undefined) {
-    return containsAggregate(node.TypeCast.arg, aggregateNames);
-  }
-
-  if (node.FuncCall !== undefined) {
-    if (node.FuncCall.over !== undefined) {
-      return false;
-    }
-
-    const funcName = node.FuncCall.funcname.at(-1)?.String?.sval?.toLowerCase();
-    return funcName !== undefined && aggregateNames.has(funcName);
-  }
-
-  if (node.A_Expr !== undefined) {
-    return (
-      (node.A_Expr.lexpr !== undefined && containsAggregate(node.A_Expr.lexpr, aggregateNames)) ||
-      (node.A_Expr.rexpr !== undefined && containsAggregate(node.A_Expr.rexpr, aggregateNames))
-    );
-  }
-
-  if (node.CoalesceExpr !== undefined) {
-    return node.CoalesceExpr.args.some((arg) => containsAggregate(arg, aggregateNames));
-  }
-
-  if (node.CaseExpr !== undefined) {
-    if (
-      node.CaseExpr.defresult !== undefined &&
-      containsAggregate(node.CaseExpr.defresult, aggregateNames)
-    ) {
-      return true;
-    }
-
-    return node.CaseExpr.args.some(
-      (arg) =>
-        (arg.CaseWhen?.expr !== undefined &&
-          containsAggregate(arg.CaseWhen.expr, aggregateNames)) ||
-        (arg.CaseWhen?.result !== undefined &&
-          containsAggregate(arg.CaseWhen.result, aggregateNames)),
-    );
-  }
-
-  return false;
 }
 
 function getDescribedSelectStmt({
@@ -1074,6 +885,13 @@ function getDescribedUnnestFunCall({
   return [{ name, type: unwrap(described.type) }];
 }
 
+const pgFnArgAliases: Record<string, string> = {
+  int4: "integer",
+  int8: "bigint",
+  float4: "real",
+  float8: "double precision",
+};
+
 function getDescribedFuncCallByPgFn({
   alias,
   context,
@@ -1081,7 +899,7 @@ function getDescribedFuncCallByPgFn({
 }: GetDescribedParamsOf<LibPgQueryAST.FuncCall>): ASTDescribedColumn[] {
   const functionName = node.funcname.at(-1)?.String?.sval;
   const name = alias ?? functionName ?? "?column?";
-  const argTypes = (node.args ?? []).flatMap((argNode) => {
+  const pgArgs = (node.args ?? []).flatMap((argNode) => {
     const described = getDescribedNode({ alias: undefined, node: argNode, context }).at(0);
 
     if (described === undefined) {
@@ -1093,43 +911,37 @@ function getDescribedFuncCallByPgFn({
         ? unwrapNullableUnionType(described.type)
         : described.type.kind === "type"
           ? described.type
-          : undefined;
+          : described.type.kind === "literal" && described.type.base.kind === "type"
+            ? described.type.base
+            : undefined;
 
-    if (unwrapped?.kind === "type") {
-      return [{ ts: unwrapped.value, pg: unwrapped.type }];
-    }
-
-    return [];
+    return unwrapped?.kind === "type" ? [unwrapped.type] : [];
   });
-  const args = argTypes.map((arg) => arg.ts);
 
   if (functionName === undefined) {
     return [{ name, type: context.toTypeScriptType({ name: "unknown" }) }];
   }
 
-  let pgFnValue =
-    args.length === 0
+  const pgFnLookupArgs = pgArgs.map((pgArg) => pgFnArgAliases[pgArg] ?? pgArg);
+  const tsArgs = pgArgs.map((pgArg) => context.typesMap.get(pgArg)?.value ?? "unknown");
+
+  const pgFnValue =
+    pgArgs.length === 0
       ? (context.pgFns.get(functionName) ?? context.pgFns.get(`${functionName}(string)`))
-      : (context.pgFns.get(`${functionName}(${args.join(", ")})`) ??
+      : (context.pgFns.get(`${functionName}(${pgFnLookupArgs.join(", ")})`) ??
+        context.pgFns.get(`${functionName}(${pgArgs.join(", ")})`) ??
+        context.pgFns.get(`${functionName}(${tsArgs.join(", ")})`) ??
         context.pgFns.get(`${functionName}(any)`) ??
         context.pgFns.get(`${functionName}(unknown)`));
 
-  if (
-    pgFnValue !== undefined &&
-    argTypes.length > 0 &&
-    (functionName === "max" || functionName === "min")
-  ) {
-    const argPg = argTypes[0].pg;
-    pgFnValue = {
-      ts: context.typesMap.get(argPg)?.value ?? pgFnValue.ts,
-      pg: argPg,
-    };
-  }
+  const tsReturnType = pgFnValue?.pg
+    ? (context.typesMap.get(pgFnValue.pg)?.value ?? pgFnValue.ts)
+    : (pgFnValue?.ts ?? "unknown");
 
   const type = resolveType({
     context: context,
     nullable: !context.nonNullableColumns.has(name),
-    type: { kind: "type", value: pgFnValue?.ts ?? "unknown", type: pgFnValue?.pg ?? "unknown" },
+    type: { kind: "type", value: tsReturnType, type: pgFnValue?.pg ?? "unknown" },
   });
 
   return [{ name, type }];

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -542,6 +542,32 @@ function getBaseType(type: ASTDescribedColumnType): ASTDescribedColumnType {
   }
 }
 
+function unwrapNullableUnionType(
+  type: ASTDescribedColumnType,
+): ASTDescribedColumnType | undefined {
+  if (type.kind !== "union") {
+    return undefined;
+  }
+
+  const nonNull = type.value.flatMap((member) => {
+    if (member.kind === "type" && member.value === "null") {
+      return [];
+    }
+
+    if (member.kind === "type") {
+      return [member];
+    }
+
+    return [];
+  });
+
+  if (nonNull.length === 0) {
+    return undefined;
+  }
+
+  return isSingleCell(nonNull) ? nonNull[0] : mergeDescribedColumnTypes(nonNull);
+}
+
 function getDescribedBoolExpr({
   alias,
   context,
@@ -650,7 +676,7 @@ function producesExactlyOneRow(
   }
 
   if (isAggregateTarget) {
-    return true;
+    return select.limitCount === undefined || isPositiveLimitCount(select.limitCount);
   }
 
   const hasFromClause = (select.fromClause?.length ?? 0) > 0;
@@ -670,6 +696,10 @@ function caseExprProducesExactlyOneRow(
   caseExpr: LibPgQueryAST.CaseExpr,
   aggregateNames: Set<string>,
 ): boolean {
+  if (caseExpr.defresult === undefined) {
+    return false;
+  }
+
   const branches = [...caseExpr.args.map((arg) => arg.CaseWhen?.result), caseExpr.defresult].filter(
     (node): node is LibPgQueryAST.Node => node !== undefined,
   );
@@ -701,6 +731,26 @@ function isConstantSingleRowExpression(node: LibPgQueryAST.Node): boolean {
   }
 
   return false;
+}
+
+function isPositiveLimitCount(limitCount: LibPgQueryAST.Node): boolean {
+  const value = getConstantIntegerValue(limitCount);
+
+  return value !== undefined && value > 0;
+}
+
+function getConstantIntegerValue(node: LibPgQueryAST.Node): number | undefined {
+  if (node.A_Const?.ival !== undefined) {
+    const ival = node.A_Const.ival;
+
+    return typeof ival === "number" ? ival : ival.ival;
+  }
+
+  if (node.TypeCast?.arg !== undefined) {
+    return getConstantIntegerValue(node.TypeCast.arg);
+  }
+
+  return undefined;
 }
 
 function containsAggregate(node: LibPgQueryAST.Node, aggregateNames: Set<string>): boolean {
@@ -1034,8 +1084,19 @@ function getDescribedFuncCallByPgFn({
   const argTypes = (node.args ?? []).flatMap((argNode) => {
     const described = getDescribedNode({ alias: undefined, node: argNode, context }).at(0);
 
-    if (described?.type.kind === "type") {
-      return [{ ts: described.type.value, pg: described.type.type }];
+    if (described === undefined) {
+      return [];
+    }
+
+    const unwrapped =
+      described.type.kind === "union"
+        ? unwrapNullableUnionType(described.type)
+        : described.type.kind === "type"
+          ? described.type
+          : undefined;
+
+    if (unwrapped?.kind === "type") {
+      return [{ ts: unwrapped.value, pg: unwrapped.type }];
     }
 
     return [];

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -10,7 +10,7 @@ import {
 } from "./ast-decribe.utils";
 import { ResolvedColumn, SourcesResolver, getSources } from "./ast-get-sources";
 import { PgColRow, PgEnumsMaps, PgTypesMap } from "./generate";
-import { getNonNullableColumns } from "./utils/get-nonnullable-columns";
+import { getNonNullableColumns, getOutputColumnKey } from "./utils/get-nonnullable-columns";
 import {
   FlattenedRelationWithJoins,
   flattenRelationsWithJoinsMap,
@@ -27,6 +27,7 @@ type ASTDescriptionOptions = {
   pgTypes: PgTypesMap;
   pgEnums: PgEnumsMaps;
   pgFns: Map<string, { ts: string; pg: string }>;
+  pgAggregateNames: Set<string>;
   fieldTransform: IdentiferCase | undefined;
   prevSources?: SourcesResolver["sources"];
   cteSelects?: Map<string, LibPgQueryAST.SelectStmt>;
@@ -584,16 +585,152 @@ function getDescribedSubLink({
     return context.toTypeScriptType({ name: "unknown" });
   };
 
+  const name = getOutputColumnKey(alias, { SubLink: node });
+  const nullable = isExprSubLinkNullable({ node, context, columnKey: name });
+  const subLinkType = getSubLinkType();
+
   return [
     {
-      name: alias ?? "exists",
+      name,
       type: resolveType({
         context: context,
-        nullable: node.subLinkType === LibPgQueryAST.SubLinkType.EXPR_SUBLINK,
-        type: getSubLinkType(),
+        nullable,
+        type: nullable ? subLinkType : asNonNullableType(subLinkType),
       }),
     },
   ];
+}
+
+function isExprSubLinkNullable(params: {
+  node: LibPgQueryAST.SubLink;
+  context: ASTDescriptionContext;
+  columnKey: string;
+}): boolean {
+  if (params.node.subLinkType !== LibPgQueryAST.SubLinkType.EXPR_SUBLINK) {
+    return false;
+  }
+
+  const select = params.node.subselect?.SelectStmt;
+
+  if (select === undefined || !producesExactlyOneRow(select, params.context.pgAggregateNames)) {
+    return true;
+  }
+
+  return !params.context.nonNullableColumns.has(params.columnKey);
+}
+
+function producesExactlyOneRow(
+  select: LibPgQueryAST.SelectStmt,
+  aggregateNames: Set<string>,
+): boolean {
+  if (
+    (select.groupClause?.length ?? 0) > 0 ||
+    select.havingClause !== undefined ||
+    select.limitCount !== undefined ||
+    select.limitOffset !== undefined
+  ) {
+    return false;
+  }
+
+  const targets = select.targetList ?? [];
+
+  if (targets.length !== 1) {
+    return false;
+  }
+
+  const target = targets[0]?.ResTarget?.val;
+
+  if (target === undefined) {
+    return false;
+  }
+
+  return (
+    containsAggregate(target, aggregateNames) ||
+    isConstantSingleRowExpression(target) ||
+    (target.CaseExpr !== undefined &&
+      caseExprProducesExactlyOneRow(target.CaseExpr, aggregateNames))
+  );
+}
+
+function caseExprProducesExactlyOneRow(
+  caseExpr: LibPgQueryAST.CaseExpr,
+  aggregateNames: Set<string>,
+): boolean {
+  const branches = [
+    ...caseExpr.args.map((arg) => arg.CaseWhen?.result),
+    caseExpr.defresult,
+  ].filter((node): node is LibPgQueryAST.Node => node !== undefined);
+
+  if (branches.length === 0) {
+    return false;
+  }
+
+  return branches.every(
+    (branch) => containsAggregate(branch, aggregateNames) || isConstantSingleRowExpression(branch),
+  );
+}
+
+function isConstantSingleRowExpression(node: LibPgQueryAST.Node): boolean {
+  if (node.A_Const !== undefined) {
+    return node.A_Const.isnull !== true;
+  }
+
+  if (node.TypeCast?.arg !== undefined) {
+    return isConstantSingleRowExpression(node.TypeCast.arg);
+  }
+
+  if (node.A_Expr !== undefined) {
+    const { lexpr, rexpr } = node.A_Expr;
+    return (
+      (lexpr === undefined || isConstantSingleRowExpression(lexpr)) &&
+      (rexpr === undefined || isConstantSingleRowExpression(rexpr))
+    );
+  }
+
+  return false;
+}
+
+function containsAggregate(node: LibPgQueryAST.Node, aggregateNames: Set<string>): boolean {
+  if (node.TypeCast?.arg !== undefined) {
+    return containsAggregate(node.TypeCast.arg, aggregateNames);
+  }
+
+  if (node.FuncCall !== undefined) {
+    if (node.FuncCall.over !== undefined) {
+      return false;
+    }
+
+    const funcName = node.FuncCall.funcname.at(-1)?.String?.sval?.toLowerCase();
+    return funcName !== undefined && aggregateNames.has(funcName);
+  }
+
+  if (node.A_Expr !== undefined) {
+    return (
+      (node.A_Expr.lexpr !== undefined && containsAggregate(node.A_Expr.lexpr, aggregateNames)) ||
+      (node.A_Expr.rexpr !== undefined && containsAggregate(node.A_Expr.rexpr, aggregateNames))
+    );
+  }
+
+  if (node.CoalesceExpr !== undefined) {
+    return node.CoalesceExpr.args.some((arg) => containsAggregate(arg, aggregateNames));
+  }
+
+  if (node.CaseExpr !== undefined) {
+    if (
+      node.CaseExpr.defresult !== undefined &&
+      containsAggregate(node.CaseExpr.defresult, aggregateNames)
+    ) {
+      return true;
+    }
+
+    return node.CaseExpr.args.some(
+      (arg) =>
+        arg.CaseWhen?.result !== undefined &&
+        containsAggregate(arg.CaseWhen.result, aggregateNames),
+    );
+  }
+
+  return false;
 }
 
 function getDescribedSelectStmt({
@@ -615,6 +752,7 @@ function getDescribedSelectStmt({
     pgTypes: context.pgTypes,
     pgEnums: context.pgEnums,
     pgFns: context.pgFns,
+    pgAggregateNames: context.pgAggregateNames,
     fieldTransform: context.fieldTransform,
     prevSources: context.resolver.sources,
     cteSelects: context.cteSelects,
@@ -670,11 +808,15 @@ function getDescribedArrayExpr({
   context,
   node,
 }: GetDescribedParamsOf<LibPgQueryAST.AArrayExpr>): ASTDescribedColumn[] {
-  const types = mergeDescribedColumnTypes(
-    node.elements
-      .flatMap((node) => getDescribedNode({ alias: undefined, node, context }))
-      .map((x) => x.type),
-  );
+  const elements = node.elements ?? [];
+  const types =
+    elements.length === 0
+      ? context.toTypeScriptType({ name: "unknown" })
+      : mergeDescribedColumnTypes(
+          elements
+            .flatMap((node) => getDescribedNode({ alias: undefined, node, context }))
+            .map((x) => x.type),
+        );
 
   return [
     {
@@ -747,7 +889,9 @@ function getDescribedTypeCast({
     return [];
   }
 
-  const type = context.toTypeScriptType({ name: typeName });
+  const isArrayCast = (node.typeName?.arrayBounds?.length ?? 0) > 0;
+  const baseType = context.toTypeScriptType({ name: typeName });
+  const type: ASTDescribedColumnType = isArrayCast ? { kind: "array", value: baseType } : baseType;
   const innerDescribed = getDescribedNode({ alias, node: node.arg, context }).at(0);
   const nullable = fmap(innerDescribed, (x) => isDescribedColumnNullable(x.type)) ?? true;
 
@@ -1325,6 +1469,7 @@ function getDescribedColumnsFromSelect(params: {
     pgTypes: params.context.pgTypes,
     pgEnums: params.context.pgEnums,
     pgFns: params.context.pgFns,
+    pgAggregateNames: params.context.pgAggregateNames,
     fieldTransform: params.context.fieldTransform,
     prevSources: params.context.resolver.sources,
     cteSelects: params.context.cteSelects,

--- a/packages/generate/src/ast-get-sources.ts
+++ b/packages/generate/src/ast-get-sources.ts
@@ -162,7 +162,7 @@ export function getSources({
       sourcesArr.push(...getNodeColumnAndSources(node.JoinExpr.rarg));
     }
 
-    if (node.RangeSubselect?.subquery?.SelectStmt?.fromClause !== undefined) {
+    if (node.RangeSubselect?.subquery?.SelectStmt !== undefined) {
       const combinedPrevSources = new Map([
         ...(prevSources?.entries() ?? []),
         ...sourcesArr.map((x) => [x.name, x] as const),

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -3017,7 +3017,7 @@ test("scalar subquery wrapping sum() over empty rows should be nullable", async 
         {
           kind: "union",
           value: [
-            { kind: "type", value: "string", type: "numeric" },
+            { kind: "type", value: "string", type: "int8" },
             { kind: "type", value: "null", type: "null" },
           ],
         },

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -2981,7 +2981,7 @@ test("scalar subquery wrapping max() should be nullable", async () => {
         {
           kind: "union",
           value: [
-            { kind: "type", value: "string", type: "int8" },
+            { kind: "type", value: "string", type: "text" },
             { kind: "type", value: "null", type: "null" },
           ],
         },
@@ -3080,21 +3080,10 @@ test("scalar subquery with HAVING should be nullable even when wrapping count()"
   });
 });
 
-test("scalar subquery with LIMIT should be nullable even when wrapping count()", async () => {
+test("scalar subquery with LIMIT wrapping count() should be non-nullable", async () => {
   await testQuery({
     query: `SELECT (SELECT count(*)::int FROM caregiver LIMIT 1) AS c`,
-    expected: [
-      [
-        "c",
-        {
-          kind: "union",
-          value: [
-            { kind: "type", value: "number", type: "int4" },
-            { kind: "type", value: "null", type: "null" },
-          ],
-        },
-      ],
-    ],
+    expected: [["c", { kind: "type", value: "number", type: "int4" }]],
   });
 });
 
@@ -3127,10 +3116,7 @@ test("ARRAY[]::int[] should infer empty integer array", async () => {
   await testQuery({
     query: `SELECT ARRAY[]::int[] AS empty_ints`,
     expected: [
-      [
-        "empty_ints",
-        { kind: "array", value: { kind: "type", value: "number", type: "int4" } },
-      ],
+      ["empty_ints", { kind: "array", value: { kind: "type", value: "number", type: "int4" } }],
     ],
   });
 });
@@ -3248,5 +3234,54 @@ test("scalar subquery selecting a constant should be non-nullable", async () => 
         },
       ],
     ],
+  });
+});
+
+test("scalar subquery with constant and WHERE false should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT 1 WHERE false) AS n`,
+    expected: [
+      [
+        "n",
+        {
+          kind: "union",
+          value: [
+            { kind: "literal", value: "1", base: { kind: "type", value: "number", type: "int4" } },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with constant FROM table WHERE false should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT 1 FROM caregiver WHERE false) AS n`,
+    expected: [
+      [
+        "n",
+        {
+          kind: "union",
+          value: [
+            { kind: "literal", value: "1", base: { kind: "type", value: "number", type: "int4" } },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with aggregate in CASE WHEN should be non-nullable", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT (
+        SELECT CASE WHEN count(*) > 0 THEN 1 ELSE 0 END
+        FROM caregiver
+        WHERE false
+      ) AS c
+    `,
+    expected: [["c", { kind: "type", value: "number", type: "int4" }]],
   });
 });

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -2890,3 +2890,363 @@ test("select unnest(array_with_nulls)", async () => {
     ],
   });
 });
+
+test("scalar subquery wrapping count() should be non-nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT COUNT(*)::int FROM caregiver WHERE FALSE) AS count`,
+    expected: [["count", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
+test("derived table with CROSS JOIN json_array_elements should not throw", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT code
+      FROM (
+        SELECT value ->> 'code'::TEXT code
+        FROM all_types
+        CROSS JOIN json_array_elements(json_column) value
+      ) codes
+    `,
+    expected: [
+      [
+        "code",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "text" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+    unknownColumns: ["code"],
+  });
+});
+
+test("LEFT JOIN LATERAL with empty array constructor should infer nullable text array", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT
+        caregiver.id,
+        incident_data.incidents AS incident_ids
+      FROM caregiver
+      LEFT JOIN LATERAL (
+        SELECT ARRAY[]::text[] AS incidents
+      ) AS incident_data ON true
+    `,
+    expected: [
+      ["id", { kind: "type", value: "number", type: "int4" }],
+      [
+        "incident_ids",
+        {
+          kind: "union",
+          value: [
+            { kind: "array", value: { kind: "type", value: "string", type: "text" } },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery wrapping count(*) without cast should be non-nullable bigint", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*) FROM caregiver) AS c`,
+    expected: [["c", { kind: "type", value: "string", type: "int8" }]],
+  });
+});
+
+test("scalar subquery wrapping count(distinct x) should be non-nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(DISTINCT id)::int FROM caregiver WHERE FALSE) AS c`,
+    expected: [["c", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
+test("scalar subquery wrapping count() + 1 should be non-nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*)::int + 1 FROM caregiver WHERE FALSE) AS c`,
+    expected: [["c", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
+test("scalar subquery wrapping max() should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT max(first_name) FROM caregiver) AS m`,
+    expected: [
+      [
+        "m",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "int8" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery wrapping sum() should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT sum(id) FROM caregiver) AS s`,
+    expected: [
+      [
+        "s",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "int8" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery wrapping sum() over empty rows should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT sum(0) FROM caregiver WHERE FALSE) AS s`,
+    expected: [
+      [
+        "s",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "numeric" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery wrapping array_agg() should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT array_agg(id) FROM caregiver) AS ids`,
+    expected: [
+      [
+        "ids",
+        {
+          kind: "union",
+          value: [
+            { kind: "array", value: { kind: "type", value: "number", type: "int4" } },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with GROUP BY should be nullable even when wrapping count()", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*)::int FROM caregiver GROUP BY id LIMIT 1) AS c`,
+    expected: [
+      [
+        "c",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with HAVING should be nullable even when wrapping count()", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*)::int FROM caregiver HAVING count(*) > 0) AS c`,
+    expected: [
+      [
+        "c",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with LIMIT should be nullable even when wrapping count()", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*)::int FROM caregiver LIMIT 1) AS c`,
+    expected: [
+      [
+        "c",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery selecting a column should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT id FROM caregiver LIMIT 1) AS id`,
+    expected: [
+      [
+        "id",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("EXISTS subquery should remain non-nullable boolean", async () => {
+  await testQuery({
+    query: `SELECT EXISTS(SELECT 1 FROM caregiver WHERE FALSE) AS has_any`,
+    expected: [["has_any", { kind: "type", value: "boolean", type: "bool" }]],
+  });
+});
+
+test("ARRAY[]::int[] should infer empty integer array", async () => {
+  await testQuery({
+    query: `SELECT ARRAY[]::int[] AS empty_ints`,
+    expected: [
+      [
+        "empty_ints",
+        { kind: "array", value: { kind: "type", value: "number", type: "int4" } },
+      ],
+    ],
+  });
+});
+
+test("INNER JOIN with set-returning function should not throw", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT t.id, v.value
+      FROM all_types t
+      INNER JOIN json_array_elements(t.json_column) AS v ON true
+    `,
+    expected: [
+      ["id", { kind: "type", value: "number", type: "int4" }],
+      ["value", { kind: "type", value: "any", type: "json" }],
+    ],
+    unknownColumns: ["value"],
+  });
+});
+
+test("unnamed scalar subquery wrapping count() should be non-nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*) FROM caregiver)`,
+    expected: [["count", { kind: "type", value: "string", type: "int8" }]],
+  });
+});
+
+test("scalar subquery wrapping count(*) OVER () should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*) OVER () FROM caregiver) AS c`,
+    expected: [
+      [
+        "c",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "int8" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with UNION of counts should be nullable", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT (
+        SELECT count(*)::int FROM caregiver
+        UNION
+        SELECT count(*)::int FROM caregiver_agency
+      ) AS c
+    `,
+    expected: [
+      [
+        "c",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery wrapping percentile_cont stays nullable on empty input", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT (
+        SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY id)
+        FROM caregiver
+      ) AS p
+    `,
+    expected: [
+      [
+        "p",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "unknown", type: "unknown" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with count() inside CASE should be non-nullable", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT (
+        SELECT CASE WHEN true THEN count(*)::int ELSE 0 END
+        FROM caregiver
+        WHERE FALSE
+      ) AS c
+    `,
+    expected: [["c", { kind: "type", value: "number", type: "int4" }]],
+  });
+});
+
+test("scalar subquery selecting a constant should be non-nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT 1) AS n`,
+    expected: [
+      [
+        "n",
+        {
+          kind: "literal",
+          value: "1",
+          base: { kind: "type", value: "number", type: "int4" },
+        },
+      ],
+    ],
+  });
+});

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -3087,6 +3087,60 @@ test("scalar subquery with LIMIT wrapping count() should be non-nullable", async
   });
 });
 
+test("scalar subquery with LIMIT 0 wrapping count() should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT count(*)::int FROM caregiver LIMIT 0) AS c`,
+    expected: [
+      [
+        "c",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("max() on nullable column should resolve argument type", async () => {
+  await testQuery({
+    query: `SELECT max(nullable_col) AS m FROM test_nullability`,
+    expected: [
+      [
+        "m",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "text" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
+test("scalar subquery with CASE without ELSE should be nullable", async () => {
+  await testQuery({
+    query: `SELECT (SELECT CASE WHEN false THEN 1 END) AS n`,
+    expected: [
+      [
+        "n",
+        {
+          kind: "union",
+          value: [
+            { kind: "literal", value: "1", base: { kind: "type", value: "number", type: "int4" } },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
 test("scalar subquery selecting a column should be nullable", async () => {
   await testQuery({
     query: `SELECT (SELECT id FROM caregiver LIMIT 1) AS id`,

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -184,11 +184,6 @@ async function generate(
     },
   });
 
-  function byReturnType(a: PgFnRow, b: PgFnRow) {
-    const priority = ["numeric", "int8"];
-    return priority.indexOf(a.returnType) - priority.indexOf(b.returnType);
-  }
-
   const functionsMap = await getOrSetFromMapWithEnabled({
     shouldCache: cacheMetadata,
     map: cache.functions,
@@ -197,16 +192,28 @@ async function generate(
       const map: FunctionsMap = new Map();
 
       for (const [functionName, signatures] of pgFnsByName.entries()) {
-        for (const signature of signatures.sort(byReturnType)) {
+        for (const signature of signatures) {
+          if (signature.arguments.some((arg) => arg.includes("ORDER BY"))) {
+            continue;
+          }
+
           const tsArgs = signature.arguments.map((arg) => {
             return typesMap.get(arg)?.value ?? "unknown";
           });
-
           const tsReturnType = typesMap.get(signature.returnType)?.value ?? signature.returnType;
+          const entry = { ts: tsReturnType, pg: signature.returnType };
 
-          const key = tsArgs.length === 0 ? functionName : `${functionName}(${tsArgs.join(", ")})`;
+          const pgKey =
+            signature.arguments.length === 0
+              ? functionName
+              : `${functionName}(${signature.arguments.join(", ")})`;
+          const tsKey = tsArgs.length === 0 ? functionName : `${functionName}(${tsArgs.join(", ")})`;
 
-          map.set(key, { ts: tsReturnType, pg: signature.returnType });
+          map.set(pgKey, entry);
+
+          if (tsKey !== pgKey) {
+            map.set(tsKey, entry);
+          }
         }
       }
 

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -73,6 +73,7 @@ type Cache = {
       pgColsByTableOidCache: Map<number, PgColRow[]>;
       pgColsBySchemaAndTableName: Map<string, Map<string, PgColRow[]>>;
       pgFnsByName: Map<string, PgFnRow[]>;
+      pgAggregateNames: Set<string>;
       pgTypeExprMap: Map<string, Map<string, Map<string, string>>>;
     }
   >;
@@ -131,6 +132,7 @@ async function generate(
     pgTypes,
     pgEnums,
     pgFnsByName,
+    pgAggregateNames,
     pgTypeExprMap,
   } = await getOrSetFromMapWithEnabled({
     shouldCache: cacheMetadata,
@@ -270,6 +272,7 @@ async function generate(
       pgTypes: pgTypes,
       pgEnums: pgEnums,
       pgFns: functionsMap,
+      pgAggregateNames,
       typeExprMap: pgTypeExprMap,
       fieldTransform: params.fieldTransform,
     });
@@ -332,6 +335,7 @@ async function getDatabaseMetadata(sql: Sql) {
   const pgCols = await getPgCols(sql);
   const pgEnums = await getPgEnums(sql);
   const pgFns = await getPgFunctions(sql);
+  const pgAggregateNames = await getPgAggregateFunctionNames(sql);
   const pgColsByTableOidCache = groupBy(pgCols, "tableOid");
   const pgColsBySchemaAndTableName = groupBy(pgCols, "schemaName", "tableName");
   const pgFnsByName = groupBy(pgFns, "name");
@@ -344,6 +348,7 @@ async function getDatabaseMetadata(sql: Sql) {
     pgColsByTableOidCache,
     pgColsBySchemaAndTableName,
     pgFnsByName,
+    pgAggregateNames,
     pgTypeExprMap,
   };
 }
@@ -647,6 +652,16 @@ export interface PgFnRow {
   name: string;
   arguments: string[];
   returnType: string;
+}
+
+async function getPgAggregateFunctionNames(sql: Sql): Promise<Set<string>> {
+  const rows = await sql<{ name: string }[]>`
+      SELECT DISTINCT proname AS name
+      FROM pg_catalog.pg_proc
+      WHERE prokind = 'a'
+  `;
+
+  return new Set(rows.map((row) => row.name));
 }
 
 async function getPgFunctions(sql: Sql) {

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -207,7 +207,8 @@ async function generate(
             signature.arguments.length === 0
               ? functionName
               : `${functionName}(${signature.arguments.join(", ")})`;
-          const tsKey = tsArgs.length === 0 ? functionName : `${functionName}(${tsArgs.join(", ")})`;
+          const tsKey =
+            tsArgs.length === 0 ? functionName : `${functionName}(${tsArgs.join(", ")})`;
 
           map.set(pgKey, entry);
 

--- a/packages/generate/src/utils/get-nonnullable-columns.test.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.test.ts
@@ -6,10 +6,13 @@ import parser from "libpg-query";
 import { test } from "vitest";
 import { getNonNullableColumns } from "./get-nonnullable-columns";
 
+const testAggregates = new Set(["count", "sum", "max", "min", "avg", "array_agg"]);
+
 const cases: {
   query: string;
   expected: string[];
   only?: boolean;
+  aggregateNames?: Set<string>;
 }[] = [
   { query: `SELECT 1`, expected: ["?column?"] },
   { query: `SELECT 2 as x`, expected: ["x"] },
@@ -46,7 +49,17 @@ const cases: {
   { query: `SELECT ARRAY[null]`, expected: ["array"] },
   { query: `SELECT ARRAY(SELECT 1)`, expected: ["array"] },
   { query: `SELECT ARRAY(SELECT tbl.col FROM tbl WHERE tbl.col IS NOT NULL)`, expected: ["array"] },
-  { query: `SELECT (SELECT 1 AS X)`, expected: ["x"] },
+  { query: `SELECT (SELECT 1 AS X)`, expected: ["x"], aggregateNames: testAggregates },
+  {
+    query: `SELECT (SELECT count(*) FROM caregiver) AS c`,
+    expected: ["c"],
+    aggregateNames: testAggregates,
+  },
+  {
+    query: `SELECT (SELECT count(*) FROM caregiver GROUP BY id) AS c`,
+    expected: [],
+    aggregateNames: testAggregates,
+  },
   { query: `SELECT a, b FROM tbl WHERE b IS NOT NULL`, expected: ["b"] },
   { query: `SELECT a, b FROM tbl WHERE b IS NOT NULL AND a IS NOT NULL`, expected: ["b", "a"] },
   {
@@ -78,18 +91,19 @@ const cases: {
   { query: `SELECT tbl.col FROM tbl WHERE tbl.col IS NOT NULL`, expected: ["tbl.col"] },
 ];
 
-export const getNonNullableColumnsTE = flow(
-  parser.parse,
-  taskEither.tryCatchK(identity, InternalError.to),
-  taskEither.map(getNonNullableColumns),
-  taskEither.map((set) => Array.from(set)),
-);
+const getNonNullableColumnsTE = (aggregateNames?: Set<string>) =>
+  flow(
+    parser.parse,
+    taskEither.tryCatchK(identity, InternalError.to),
+    taskEither.map((parsed) => getNonNullableColumns(parsed, { aggregateNames })),
+    taskEither.map((set) => Array.from(set)),
+  );
 
-for (const { query, expected, only } of cases) {
+for (const { query, expected, only, aggregateNames } of cases) {
   const tester = only ? test.only : test;
   tester(`get non-nullable columns: ${query}`, async () => {
     return pipe(
-      getNonNullableColumnsTE(query),
+      getNonNullableColumnsTE(aggregateNames)(query),
       taskEither.match(
         (error) => assert.fail(error.message),
         (result) => assert.deepEqual(result, expected),

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -568,19 +568,3 @@ export function getNonNullableColumns(
 
   return new Set();
 }
-
-export function unwrapNullableUnionType(type: {
-  kind: "union";
-  value: { kind: string; value: string; type: string }[];
-}): { kind: "type"; value: string; type: string } | undefined {
-  const nonNull = type.value.filter(
-    (member): member is { kind: "type"; value: string; type: string } =>
-      member.kind === "type" && member.value !== "null",
-  );
-
-  if (nonNull.length !== 1) {
-    return undefined;
-  }
-
-  return nonNull[0];
-}

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -265,6 +265,17 @@ function getTargetName(target: LibPgQueryAST.ResTarget): string {
   return target.name ?? getNodeName(target.val);
 }
 
+export function getOutputColumnKey(
+  alias: string | undefined,
+  value: LibPgQueryAST.Node | undefined,
+): string {
+  if (alias !== undefined) {
+    return alias;
+  }
+
+  return getNodeName(value);
+}
+
 function addColumnRef(nonNullableColumns: Set<string>, node: LibPgQueryAST.Node | undefined) {
   if (node?.ColumnRef?.fields !== undefined) {
     nonNullableColumns.add(concatStringNodes(node.ColumnRef.fields));

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -169,7 +169,10 @@ function isColumnNonNullable(
       }
     }
 
-    if (val.CaseExpr.defresult && !isColumnNonNullable(val.CaseExpr.defresult, root, aggregateNames)) {
+    if (
+      val.CaseExpr.defresult &&
+      !isColumnNonNullable(val.CaseExpr.defresult, root, aggregateNames)
+    ) {
       return false;
     }
 

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -1,5 +1,6 @@
 import { assertNever } from "@ts-safeql/shared";
 import * as LibPgQueryAST from "@ts-safeql/sql-ast";
+import { selectReturnsExactlyOneRow } from "./scalar-subquery-row-count";
 
 // Function names that are always non-nullable.
 const nonNullFunctions: Set<string> = new Set([
@@ -79,6 +80,7 @@ function concatStringNodes(nodes: LibPgQueryAST.Node[] | undefined): string {
 function isColumnNonNullable(
   val: LibPgQueryAST.Node | undefined,
   root: LibPgQueryAST.ParseResult,
+  aggregateNames: Set<string> | undefined,
 ): boolean {
   if (val === undefined) {
     return false;
@@ -102,7 +104,7 @@ function isColumnNonNullable(
   }
 
   if (val.TypeCast?.arg) {
-    return isColumnNonNullable(val.TypeCast.arg, root);
+    return isColumnNonNullable(val.TypeCast.arg, root, aggregateNames);
   }
 
   if (val.SubLink) {
@@ -116,10 +118,25 @@ function isColumnNonNullable(
       case LibPgQueryAST.SubLinkType.ALL_SUBLINK:
       case LibPgQueryAST.SubLinkType.ANY_SUBLINK:
       case LibPgQueryAST.SubLinkType.ROWCOMPARE_SUBLINK:
-      case LibPgQueryAST.SubLinkType.EXPR_SUBLINK:
+      case LibPgQueryAST.SubLinkType.EXPR_SUBLINK: {
+        const innerSelect = val.SubLink.subselect?.SelectStmt;
+
+        if (
+          innerSelect === undefined ||
+          aggregateNames === undefined ||
+          !selectReturnsExactlyOneRow(innerSelect, aggregateNames)
+        ) {
+          return false;
+        }
+
+        const expression = innerSelect.targetList?.[0]?.ResTarget?.val;
+
+        return expression !== undefined && isColumnNonNullable(expression, root, aggregateNames);
+      }
+
       case LibPgQueryAST.SubLinkType.MULTIEXPR_SUBLINK:
       case LibPgQueryAST.SubLinkType.CTE_SUBLINK:
-        return isColumnNonNullable(val.SubLink.subselect, root);
+        return isColumnNonNullable(val.SubLink.subselect, root, aggregateNames);
 
       case LibPgQueryAST.SubLinkType.SUB_LINK_TYPE_UNDEFINED:
       case LibPgQueryAST.SubLinkType.UNRECOGNIZED:
@@ -140,18 +157,19 @@ function isColumnNonNullable(
 
   if (val.A_Expr?.kind === LibPgQueryAST.AExprKind.AEXPR_OP) {
     return (
-      isColumnNonNullable(val.A_Expr.lexpr, root) && isColumnNonNullable(val.A_Expr.rexpr, root)
+      isColumnNonNullable(val.A_Expr.lexpr, root, aggregateNames) &&
+      isColumnNonNullable(val.A_Expr.rexpr, root, aggregateNames)
     );
   }
 
   if (val.CaseExpr) {
     for (const when of val.CaseExpr.args) {
-      if (!isColumnNonNullable(when.CaseWhen?.result, root)) {
+      if (!isColumnNonNullable(when.CaseWhen?.result, root, aggregateNames)) {
         return false;
       }
     }
 
-    if (val.CaseExpr.defresult && !isColumnNonNullable(val.CaseExpr.defresult, root)) {
+    if (val.CaseExpr.defresult && !isColumnNonNullable(val.CaseExpr.defresult, root, aggregateNames)) {
       return false;
     }
 
@@ -180,7 +198,7 @@ function isColumnNonNullable(
 
   if (val.CoalesceExpr) {
     for (const arg of val.CoalesceExpr.args) {
-      if (isColumnNonNullable(arg, root)) {
+      if (isColumnNonNullable(arg, root, aggregateNames)) {
         return true;
       }
     }
@@ -192,9 +210,13 @@ function isColumnNonNullable(
   }
 
   if (val.SelectStmt) {
-    // TODO: maybe we should check the sublink type?
-    const nonNullableColumnsInSubStmt = getNonNullableColumnsInSelectStmt(val.SelectStmt, root);
-    return Array.from(nonNullableColumnsInSubStmt.values()).some(Boolean);
+    const nonNullableColumnsInSubStmt = getNonNullableColumnsInSelectStmt(
+      val.SelectStmt,
+      root,
+      aggregateNames,
+    );
+
+    return nonNullableColumnsInSubStmt.size > 0;
   }
 
   return false;
@@ -309,6 +331,7 @@ function addNonNullableColumnsFromSubselect(
   nonNullableColumns: Set<string>,
   node: LibPgQueryAST.Node,
   root: LibPgQueryAST.ParseResult,
+  aggregateNames: Set<string> | undefined,
 ) {
   const select = node.RangeSubselect?.subquery?.SelectStmt;
 
@@ -316,7 +339,7 @@ function addNonNullableColumnsFromSubselect(
     return;
   }
 
-  for (const name of getNonNullableColumnsInSelectStmt(select, root)) {
+  for (const name of getNonNullableColumnsInSelectStmt(select, root, aggregateNames)) {
     nonNullableColumns.add(name);
   }
 }
@@ -326,9 +349,10 @@ function addNonNullableColumnsFromFromNode(
   node: LibPgQueryAST.Node,
   root: LibPgQueryAST.ParseResult,
   isNullable: boolean,
+  aggregateNames: Set<string> | undefined,
 ) {
   if (!isNullable) {
-    addNonNullableColumnsFromSubselect(nonNullableColumns, node, root);
+    addNonNullableColumnsFromSubselect(nonNullableColumns, node, root, aggregateNames);
   }
 
   const joinExpr = node.JoinExpr;
@@ -347,11 +371,23 @@ function addNonNullableColumnsFromFromNode(
       }
 
       if (joinExpr.larg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, isNullable);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.larg,
+          root,
+          isNullable,
+          aggregateNames,
+        );
       }
 
       if (joinExpr.rarg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, isNullable);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.rarg,
+          root,
+          isNullable,
+          aggregateNames,
+        );
       }
 
       break;
@@ -360,22 +396,46 @@ function addNonNullableColumnsFromFromNode(
     case LibPgQueryAST.JoinType.JOIN_ANTI:
     case LibPgQueryAST.JoinType.JOIN_UNIQUE_OUTER:
       if (joinExpr.larg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, isNullable);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.larg,
+          root,
+          isNullable,
+          aggregateNames,
+        );
       }
 
       if (joinExpr.rarg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, true);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.rarg,
+          root,
+          true,
+          aggregateNames,
+        );
       }
 
       break;
 
     case LibPgQueryAST.JoinType.JOIN_RIGHT:
       if (joinExpr.larg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, true);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.larg,
+          root,
+          true,
+          aggregateNames,
+        );
       }
 
       if (joinExpr.rarg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, isNullable);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.rarg,
+          root,
+          isNullable,
+          aggregateNames,
+        );
       }
 
       break;
@@ -383,11 +443,23 @@ function addNonNullableColumnsFromFromNode(
     case LibPgQueryAST.JoinType.JOIN_FULL:
     case LibPgQueryAST.JoinType.UNRECOGNIZED:
       if (joinExpr.larg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.larg, root, true);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.larg,
+          root,
+          true,
+          aggregateNames,
+        );
       }
 
       if (joinExpr.rarg !== undefined) {
-        addNonNullableColumnsFromFromNode(nonNullableColumns, joinExpr.rarg, root, true);
+        addNonNullableColumnsFromFromNode(
+          nonNullableColumns,
+          joinExpr.rarg,
+          root,
+          true,
+          aggregateNames,
+        );
       }
 
       break;
@@ -419,6 +491,7 @@ function addNonNullableTargetAliases(
 function getNonNullableColumnsInSelectStmt(
   stmt: LibPgQueryAST.SelectStmt,
   root: LibPgQueryAST.ParseResult,
+  aggregateNames: Set<string> | undefined,
 ): Set<string> {
   const nonNullableColumns = new Set<string>();
 
@@ -435,7 +508,7 @@ function getNonNullableColumnsInSelectStmt(
       targetNames.add(getTargetName(target.ResTarget));
     }
 
-    if (target.ResTarget && isColumnNonNullable(target.ResTarget.val, root)) {
+    if (target.ResTarget && isColumnNonNullable(target.ResTarget.val, root, aggregateNames)) {
       nonNullableColumns.add(getTargetName(target.ResTarget));
     }
   }
@@ -473,7 +546,7 @@ function getNonNullableColumnsInSelectStmt(
   }
 
   for (const from of stmt.fromClause ?? []) {
-    addNonNullableColumnsFromFromNode(nonNullableColumns, from, root, false);
+    addNonNullableColumnsFromFromNode(nonNullableColumns, from, root, false, aggregateNames);
   }
 
   addNonNullableTargetAliases(nonNullableColumns, targetList);
@@ -481,12 +554,33 @@ function getNonNullableColumnsInSelectStmt(
   return nonNullableColumns;
 }
 
-export function getNonNullableColumns(root: LibPgQueryAST.ParseResult): Set<string> {
+export function getNonNullableColumns(
+  root: LibPgQueryAST.ParseResult,
+  options?: { aggregateNames?: Set<string> },
+): Set<string> {
+  const aggregateNames = options?.aggregateNames;
+
   for (const stmt of root.stmts) {
     if (stmt.stmt?.SelectStmt) {
-      return getNonNullableColumnsInSelectStmt(stmt.stmt.SelectStmt, root);
+      return getNonNullableColumnsInSelectStmt(stmt.stmt.SelectStmt, root, aggregateNames);
     }
   }
 
   return new Set();
+}
+
+export function unwrapNullableUnionType(type: {
+  kind: "union";
+  value: { kind: string; value: string; type: string }[];
+}): { kind: "type"; value: string; type: string } | undefined {
+  const nonNull = type.value.filter(
+    (member): member is { kind: "type"; value: string; type: string } =>
+      member.kind === "type" && member.value !== "null",
+  );
+
+  if (nonNull.length !== 1) {
+    return undefined;
+  }
+
+  return nonNull[0];
 }

--- a/packages/generate/src/utils/get-relations-with-joins.test.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.test.ts
@@ -130,6 +130,19 @@ const cases: {
       ],
     ],
   },
+  {
+    query: `
+      SELECT t.id
+      FROM all_types t
+      CROSS JOIN json_array_elements(t.json_column) AS v
+    `,
+    expected: [
+      [
+        "all_types",
+        [{ alias: undefined, name: "v", type: LibPgQueryAST.JoinType.JOIN_INNER }],
+      ],
+    ],
+  },
 ];
 
 export const getRelationsWithJoinsTE = flow(

--- a/packages/generate/src/utils/get-relations-with-joins.test.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.test.ts
@@ -137,10 +137,7 @@ const cases: {
       CROSS JOIN json_array_elements(t.json_column) AS v
     `,
     expected: [
-      [
-        "all_types",
-        [{ alias: undefined, name: "v", type: LibPgQueryAST.JoinType.JOIN_INNER }],
-      ],
+      ["all_types", [{ alias: undefined, name: "v", type: LibPgQueryAST.JoinType.JOIN_INNER }]],
     ],
   },
 ];

--- a/packages/generate/src/utils/get-relations-with-joins.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.ts
@@ -32,7 +32,11 @@ function recursiveGetJoinName(joinExpr: LibPgQueryAST.JoinExpr): string | undefi
     return recursiveGetJoinName(joinExpr.rarg.JoinExpr);
   }
 
-  return joinExpr.rarg?.RangeVar?.relname ?? joinExpr.rarg?.RangeSubselect?.alias?.aliasname;
+  return (
+    joinExpr.rarg?.RangeVar?.relname ??
+    joinExpr.rarg?.RangeSubselect?.alias?.aliasname ??
+    joinExpr.rarg?.RangeFunction?.alias?.aliasname
+  );
 }
 
 function recursiveTraverseJoins(

--- a/packages/generate/src/utils/scalar-subquery-row-count.test.ts
+++ b/packages/generate/src/utils/scalar-subquery-row-count.test.ts
@@ -1,0 +1,74 @@
+import parser from "libpg-query";
+import { test, expect } from "vitest";
+import { selectReturnsExactlyOneRow } from "./scalar-subquery-row-count";
+
+const aggregates = new Set(["count", "sum", "max", "min", "avg", "array_agg"]);
+
+async function parseSelect(query: string) {
+  const parsed = await parser.parse(query);
+  const select = parsed.stmts[0]?.stmt?.SelectStmt;
+
+  if (select === undefined) {
+    throw new Error(`Expected select: ${query}`);
+  }
+
+  return select;
+}
+
+test("aggregate without GROUP BY always returns one row", async () => {
+  expect(
+    selectReturnsExactlyOneRow(
+      await parseSelect("SELECT count(*) FROM caregiver WHERE false"),
+      aggregates,
+    ),
+  ).toBe(true);
+});
+
+test("aggregate with GROUP BY may return zero rows", async () => {
+  expect(
+    selectReturnsExactlyOneRow(
+      await parseSelect("SELECT count(*) FROM caregiver GROUP BY id"),
+      aggregates,
+    ),
+  ).toBe(false);
+});
+
+test("aggregate with LIMIT 0 returns zero rows", async () => {
+  expect(
+    selectReturnsExactlyOneRow(
+      await parseSelect("SELECT count(*)::int FROM caregiver LIMIT 0"),
+      aggregates,
+    ),
+  ).toBe(false);
+});
+
+test("aggregate with positive LIMIT still returns one row", async () => {
+  expect(
+    selectReturnsExactlyOneRow(
+      await parseSelect("SELECT count(*)::int FROM caregiver LIMIT 1"),
+      aggregates,
+    ),
+  ).toBe(true);
+});
+
+test("constant without FROM returns one row", async () => {
+  expect(selectReturnsExactlyOneRow(await parseSelect("SELECT 1"), aggregates)).toBe(true);
+});
+
+test("constant with FROM may return zero rows", async () => {
+  expect(
+    selectReturnsExactlyOneRow(
+      await parseSelect("SELECT 1 FROM caregiver WHERE false"),
+      aggregates,
+    ),
+  ).toBe(false);
+});
+
+test("CASE without ELSE is not guaranteed one row", async () => {
+  expect(
+    selectReturnsExactlyOneRow(
+      await parseSelect("SELECT CASE WHEN false THEN 1 END"),
+      aggregates,
+    ),
+  ).toBe(false);
+});

--- a/packages/generate/src/utils/scalar-subquery-row-count.test.ts
+++ b/packages/generate/src/utils/scalar-subquery-row-count.test.ts
@@ -66,9 +66,6 @@ test("constant with FROM may return zero rows", async () => {
 
 test("CASE without ELSE is not guaranteed one row", async () => {
   expect(
-    selectReturnsExactlyOneRow(
-      await parseSelect("SELECT CASE WHEN false THEN 1 END"),
-      aggregates,
-    ),
+    selectReturnsExactlyOneRow(await parseSelect("SELECT CASE WHEN false THEN 1 END"), aggregates),
   ).toBe(false);
 });

--- a/packages/generate/src/utils/scalar-subquery-row-count.ts
+++ b/packages/generate/src/utils/scalar-subquery-row-count.ts
@@ -109,10 +109,9 @@ function caseExpressionAlwaysOneRow(
     return false;
   }
 
-  const branches = [
-    ...caseExpr.args.map((arg) => arg.CaseWhen?.result),
-    caseExpr.defresult,
-  ].filter((node): node is LibPgQueryAST.Node => node !== undefined);
+  const branches = [...caseExpr.args.map((arg) => arg.CaseWhen?.result), caseExpr.defresult].filter(
+    (node): node is LibPgQueryAST.Node => node !== undefined,
+  );
 
   return branches.every(
     (branch) => expressionContainsAggregate(branch, aggregateNames) || expressionIsConstant(branch),

--- a/packages/generate/src/utils/scalar-subquery-row-count.ts
+++ b/packages/generate/src/utils/scalar-subquery-row-count.ts
@@ -1,0 +1,157 @@
+import * as LibPgQueryAST from "@ts-safeql/sql-ast";
+
+function getConstantInteger(node: LibPgQueryAST.Node | undefined): number | undefined {
+  if (node?.A_Const?.ival !== undefined) {
+    const ival = node.A_Const.ival;
+
+    if (typeof ival === "number") {
+      return ival;
+    }
+
+    if (ival.ival !== undefined) {
+      return ival.ival;
+    }
+
+    // libpg-query represents `LIMIT 0` as `{ ival: {} }`
+    return 0;
+  }
+
+  if (node?.TypeCast?.arg !== undefined) {
+    return getConstantInteger(node.TypeCast.arg);
+  }
+
+  return undefined;
+}
+
+function hasZeroRowLimit(select: LibPgQueryAST.SelectStmt): boolean {
+  const limit = getConstantInteger(select.limitCount);
+
+  return limit !== undefined && limit <= 0;
+}
+
+function expressionContainsAggregate(
+  node: LibPgQueryAST.Node,
+  aggregateNames: Set<string>,
+): boolean {
+  if (node.TypeCast?.arg !== undefined) {
+    return expressionContainsAggregate(node.TypeCast.arg, aggregateNames);
+  }
+
+  if (node.FuncCall !== undefined) {
+    if (node.FuncCall.over !== undefined) {
+      return false;
+    }
+
+    const funcName = node.FuncCall.funcname.at(-1)?.String?.sval?.toLowerCase();
+
+    return funcName !== undefined && aggregateNames.has(funcName);
+  }
+
+  if (node.A_Expr !== undefined) {
+    return (
+      (node.A_Expr.lexpr !== undefined &&
+        expressionContainsAggregate(node.A_Expr.lexpr, aggregateNames)) ||
+      (node.A_Expr.rexpr !== undefined &&
+        expressionContainsAggregate(node.A_Expr.rexpr, aggregateNames))
+    );
+  }
+
+  if (node.CoalesceExpr !== undefined) {
+    return node.CoalesceExpr.args.some((arg) => expressionContainsAggregate(arg, aggregateNames));
+  }
+
+  if (node.CaseExpr !== undefined) {
+    if (
+      node.CaseExpr.defresult !== undefined &&
+      expressionContainsAggregate(node.CaseExpr.defresult, aggregateNames)
+    ) {
+      return true;
+    }
+
+    return node.CaseExpr.args.some(
+      (arg) =>
+        (arg.CaseWhen?.expr !== undefined &&
+          expressionContainsAggregate(arg.CaseWhen.expr, aggregateNames)) ||
+        (arg.CaseWhen?.result !== undefined &&
+          expressionContainsAggregate(arg.CaseWhen.result, aggregateNames)),
+    );
+  }
+
+  return false;
+}
+
+function expressionIsConstant(node: LibPgQueryAST.Node): boolean {
+  if (node.A_Const !== undefined) {
+    return node.A_Const.isnull !== true;
+  }
+
+  if (node.TypeCast?.arg !== undefined) {
+    return expressionIsConstant(node.TypeCast.arg);
+  }
+
+  if (node.A_Expr !== undefined) {
+    const { lexpr, rexpr } = node.A_Expr;
+
+    return (
+      (lexpr === undefined || expressionIsConstant(lexpr)) &&
+      (rexpr === undefined || expressionIsConstant(rexpr))
+    );
+  }
+
+  return false;
+}
+
+function caseExpressionAlwaysOneRow(
+  caseExpr: LibPgQueryAST.CaseExpr,
+  aggregateNames: Set<string>,
+): boolean {
+  if (caseExpr.defresult === undefined) {
+    return false;
+  }
+
+  const branches = [
+    ...caseExpr.args.map((arg) => arg.CaseWhen?.result),
+    caseExpr.defresult,
+  ].filter((node): node is LibPgQueryAST.Node => node !== undefined);
+
+  return branches.every(
+    (branch) => expressionContainsAggregate(branch, aggregateNames) || expressionIsConstant(branch),
+  );
+}
+
+/** True when the select is guaranteed to return exactly one row (scalar subquery cannot be "empty"). */
+export function selectReturnsExactlyOneRow(
+  select: LibPgQueryAST.SelectStmt,
+  aggregateNames: Set<string>,
+): boolean {
+  if (
+    (select.groupClause?.length ?? 0) > 0 ||
+    select.havingClause !== undefined ||
+    select.limitOffset !== undefined
+  ) {
+    return false;
+  }
+
+  const target = select.targetList?.[0]?.ResTarget?.val;
+
+  if ((select.targetList?.length ?? 0) !== 1 || target === undefined) {
+    return false;
+  }
+
+  if (expressionContainsAggregate(target, aggregateNames)) {
+    return !hasZeroRowLimit(select);
+  }
+
+  if (select.limitCount !== undefined) {
+    return false;
+  }
+
+  if ((select.fromClause?.length ?? 0) > 0 || select.whereClause !== undefined) {
+    return false;
+  }
+
+  return (
+    expressionIsConstant(target) ||
+    (target.CaseExpr !== undefined && caseExpressionAlwaysOneRow(target.CaseExpr, aggregateNames))
+  );
+}


### PR DESCRIPTION
A scalar subquery is only `null` when the inner query returns no rows. Some inner queries always return exactly one row — for example `count(*)` with no `GROUP BY`, even when the `WHERE` clause matches nothing. We were still typing those as `T | null`.

This PR distinguishes “no rows” from “one row, possibly null value,” and fixes a few related inference gaps (empty typed arrays, subselects without tables, joins with functions like `json_array_elements`).

```sql
-- { count: number | null }  →  { count: number }
SELECT (SELECT count(*)::int FROM caregiver WHERE false) AS count;
```

```sql
-- { count: string | null }  →  { count: string }
SELECT (SELECT count(*) FROM caregiver);
```

```sql
-- { c: number | null }  →  { c: number }
SELECT (
  SELECT CASE WHEN true THEN count(*)::int ELSE 0 END
  FROM caregiver
  WHERE false
) AS c;
```

```sql
-- { n: number | null }  →  { n: number }
SELECT (SELECT 1) AS n;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference and nullability for scalar subqueries, empty/typed array literals, and queries involving set-returning functions and joins.

* **New Features**
  * Generator uses database aggregate information to more accurately determine when scalar subqueries are non-nullable (e.g., COUNT(*) cases).

* **Tests**
  * Added comprehensive tests for scalar subquery nullability, aggregates, empty arrays, lateral/derived-table patterns, and edge cases.

* **Documentation**
  * Added a release note describing the updated scalar subquery inference behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ts-safeql/safeql/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->