### PR TITLE
chore(plugins): add files and repository fields to slonik and postgres-js

### DIFF
--- a/.agents/docs/authoring-plugin.md
+++ b/.agents/docs/authoring-plugin.md
@@ -5,6 +5,7 @@
 - [ ] Create a new package under `packages/plugins/<name>/` (see [creating a package](creating-package.md))
 - [ ] Add `@ts-safeql/plugin-utils` as a dependency
 - [ ] Add `postgres` as a dependency (if using `createConnection`)
+- [ ] Add `@typescript-eslint/utils` as a devDependency if you import `TSESTree`/`ParserServices` types
 - [ ] Default-export a `definePlugin()` result
 - [ ] Add tests under `src/plugin.test.ts` and `src/plugin.integration.test.ts`
 - [ ] Add a demo under `demos/plugin-<name>/`

--- a/.agents/docs/creating-package.md
+++ b/.agents/docs/creating-package.md
@@ -1,7 +1,7 @@
 # Creating a New Package
 
 1. Create the directory under `packages/` (or `packages/plugins/` for plugins)
-2. Add `package.json` — mirror an existing package for the `name`, `exports`, `scripts`, and `type` fields
+2. Add `package.json` — mirror an existing package for the `name`, `repository`, `files`, `exports`, `scripts`, and `type` fields (`files` must be present so only `dist` is published, and `repository.directory` must point to the package path)
 3. Add `tsconfig.json` extending the root `tsconfig.node.json` (adjust the relative path based on depth)
 4. Add `build.config.ts` — copy from an existing package
 5. Run `pnpm install`

--- a/packages/plugins/postgres-js/package.json
+++ b/packages/plugins/postgres-js/package.json
@@ -2,6 +2,15 @@
   "name": "@ts-safeql/plugin-postgres-js",
   "version": "4.3.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/plugins/postgres-js"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "type": "module",
   "types": "dist/index.d.ts",
   "module": "dist/index.mjs",

--- a/packages/plugins/slonik/package.json
+++ b/packages/plugins/slonik/package.json
@@ -2,6 +2,15 @@
   "name": "@ts-safeql/plugin-slonik",
   "version": "4.3.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/plugins/slonik"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "type": "module",
   "types": "dist/index.d.ts",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## What

- Add `files` and `repository` to `@ts-safeql/plugin-slonik` and `@ts-safeql/plugin-postgres-js`, matching the other packages.
- Update `.agents/docs` so this doesn't recur: `creating-package.md` now lists `files`/`repository` among the fields to mirror, and `authoring-plugin.md` notes declaring `@typescript-eslint/utils` when importing its types.

## Why

Both packages were missing a `files` allow-list, so their published tarball would include `src/` (incl. tests), `.turbo/` logs, and build configs. Restricting to `["dist", "package.json"]` ships only the built output; `repository` is added for parity and provenance. The doc previously told contributors to mirror only `name`/`exports`/`scripts`/`type`, which is how the fields were missed.

No version bump — these packages haven't been published yet, so this just corrects what their first `4.3.0` release ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manifests for postgres-js and slonik to include repository metadata and to restrict published contents to only built files and the manifest.
* **Documentation**
  * Clarified plugin authoring and new-package guidance: require repository and files fields in manifests and note an eslint utils devDependency when using specific types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ts-safeql/safeql/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->