### PR TITLE
fix: resolve relName for subquery base relation in joins

### DIFF
--- a/.changeset/relname-subselect-base.md
+++ b/.changeset/relname-subselect-base.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Fix `Internal error: relName is undefined` when the base (leftmost) relation in a join is a subquery (e.g. `FROM (SELECT ...) t CROSS JOIN ...`).

--- a/packages/generate/src/generate.test.ts
+++ b/packages/generate/src/generate.test.ts
@@ -2924,6 +2924,21 @@ test("derived table with CROSS JOIN json_array_elements should not throw", async
   });
 });
 
+test("subselect base relation cross joined with subselects should not throw", async () => {
+  await testQuery({
+    query: normalizeIndent`
+      SELECT t.total, u.cnt
+      FROM (SELECT count(*)::int AS total FROM caregiver) t
+      CROSS JOIN (SELECT count(*)::int AS cnt FROM agency) u
+      CROSS JOIN (SELECT count(*)::int AS num FROM caregiver_agency) s
+    `,
+    expected: [
+      ["total", { kind: "type", value: "number", type: "int4" }],
+      ["cnt", { kind: "type", value: "number", type: "int4" }],
+    ],
+  });
+});
+
 test("LEFT JOIN LATERAL with empty array constructor should infer nullable text array", async () => {
   await testQuery({
     query: normalizeIndent`

--- a/packages/generate/src/utils/get-relations-with-joins.test.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.test.ts
@@ -140,6 +140,24 @@ const cases: {
       ["all_types", [{ alias: undefined, name: "v", type: LibPgQueryAST.JoinType.JOIN_INNER }]],
     ],
   },
+  {
+    // Base relation is a subselect, so `relName` falls back to its alias.
+    query: `
+      SELECT a.x, b.y, c.z
+      FROM (SELECT 1 AS x) a
+      CROSS JOIN (SELECT 1 AS y) b
+      CROSS JOIN (SELECT 1 AS z) c
+    `,
+    expected: [
+      [
+        "a",
+        [
+          { alias: undefined, name: "b", type: LibPgQueryAST.JoinType.JOIN_INNER },
+          { alias: undefined, name: "c", type: LibPgQueryAST.JoinType.JOIN_INNER },
+        ],
+      ],
+    ],
+  },
 ];
 
 export const getRelationsWithJoinsTE = flow(

--- a/packages/generate/src/utils/get-relations-with-joins.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.ts
@@ -65,8 +65,10 @@ function recursiveTraverseJoins(
 
   const relName =
     joinExpr.larg?.RangeVar?.relname ??
+    joinExpr.larg?.RangeSubselect?.alias?.aliasname ??
     joinExpr.larg?.RangeFunction?.alias?.aliasname ??
     joinExpr.rarg?.RangeVar?.relname ??
+    joinExpr.rarg?.RangeSubselect?.alias?.aliasname ??
     joinExpr.rarg?.RangeFunction?.alias?.aliasname;
 
   if (relName === undefined) {


### PR DESCRIPTION
Fixes `Internal error: relName is undefined` when the base (leftmost) relation in a join is a subquery, e.g. `FROM (SELECT ...) t CROSS JOIN ...`.

`relName` resolution in `get-relations-with-joins` only handled `RangeVar`/`RangeFunction`, not `RangeSubselect`. Added the subselect alias to the fallback chain.

Covered by a unit test (`get-relations-with-joins`) and an integration test (`generate`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error that occurred when using subqueries as the base table in JOIN operations. Queries with subqueries in FROM clauses followed by CROSS JOINs now execute successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ts-safeql/safeql/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->