### PR TITLE
fix: resolve branded types to their base type as query parameters

### DIFF
--- a/.changeset/branded-types-as-parameters.md
+++ b/.changeset/branded-types-as-parameters.md
@@ -1,0 +1,7 @@
+---
+"@ts-safeql/eslint-plugin": patch
+---
+
+Resolve branded types to their base type when used as query parameters.
+
+A branded type such as `string & { __brand: "ID" }` is a TypeScript intersection of a base primitive and one or more marker objects. Previously it had no corresponding PostgreSQL type, so passing one as a parameter forced a manual `as string` cast or an `overrides.types` entry. The intersection's base primitive is now used (the marker objects exist only in TypeScript), so branded values map to their underlying type automatically. This also covers arrays (`ID[]`) and nullable unions (`ID | null`). Passing a branded value against an incompatible column is still reported.

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.branded-types.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.branded-types.test.ts
@@ -1,0 +1,199 @@
+import { normalizeIndent } from "@ts-safeql/shared";
+import { checkSqlRule, ruleTester, setupCheckSqlRuleTester } from "./check-sql.test-utils";
+
+const { connections, withConnection } = setupCheckSqlRuleTester();
+
+ruleTester.run("branded types as query parameters", checkSqlRule, {
+  valid: [],
+  invalid: [
+    {
+      name: "branded string parameter is inferred as text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(id: ID<"User">) {
+          conn.query(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(id: ID<"User">) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "branded number parameter is inferred as int, not text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type NumericId = number & { readonly __brand: "NumericId" };
+        function run(id: NumericId) {
+          conn.query(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type NumericId = number & { readonly __brand: "NumericId" };
+        function run(id: NumericId) {
+          conn.query<{ col: number | null }>(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "branded string is inferred as text regardless of intersection order",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type ID<T> = { readonly __brand: "ID"; readonly __type?: T } & string;
+        function run(id: ID<"User">) {
+          conn.query(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type ID<T> = { readonly __brand: "ID"; readonly __type?: T } & string;
+        function run(id: ID<"User">) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "branded string with multiple marker objects is inferred as text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type Tagged = string & { readonly __a: 1 } & { readonly __b: 2 };
+        function run(id: Tagged) {
+          conn.query(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type Tagged = string & { readonly __a: 1 } & { readonly __b: 2 };
+        function run(id: Tagged) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "string intersected with a non-marker object is inferred as text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type Weird = string & { id: number; createdAt: string };
+        function run(value: Weird) {
+          conn.query(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type Weird = string & { id: number; createdAt: string };
+        function run(value: Weird) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "array of branded strings is inferred as text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(ids: ID<"User">[]) {
+          conn.query(sql\`SELECT \${ids} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(ids: ID<"User">[]) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${ids} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "branded string union with null is inferred as text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(id: ID<"User"> | null) {
+          conn.query(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(id: ID<"User"> | null) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${id} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "array of nullable branded strings is inferred as text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(ids: (ID<"User"> | null)[]) {
+          conn.query(sql\`SELECT \${ids} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(ids: (ID<"User"> | null)[]) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${ids} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "branded string is still rejected against a non-text column",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        function run(id: ID<"User">) {
+          return sql\`INSERT INTO test_nullable_column (nullable_int) VALUES (\${id})\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: {
+            error: 'column "nullable_int" is of type integer but expression is of type text',
+          },
+        },
+      ],
+    },
+    {
+      name: "non-branded object intersection is rejected",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        type A = { a: number };
+        type B = { b: number };
+        function run(x: A & B) {
+          return sql\`SELECT FROM member WHERE first_name = \${x}\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: { error: "No PostgreSQL type could be inferred for the intersection: A & B" },
+        },
+      ],
+    },
+    {
+      name: "intersection of two conflicting base types is rejected",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        type Weird = string & Date;
+        function run(x: Weird) {
+          return sql\`SELECT FROM member WHERE first_name = \${x}\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: {
+            error: "Intersection types must result in the same PostgreSQL type (found text, date)",
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/utils/ts-pg.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts-pg.utils.ts
@@ -388,6 +388,42 @@ function getPgTypeFromTsTypeUnion(params: {
   return E.right(firstStrategy);
 }
 
+function getPgTypeFromTsTypeIntersection(params: {
+  types: ts.Type[];
+  checker: ts.TypeChecker;
+  options: RuleOptionConnection;
+}): E.Either<string, PgTypeStrategy | null> {
+  const { types, checker, options } = params;
+
+  // A branded type intersects a base type with marker members that exist only in TypeScript
+  // (e.g. `{ __brand: "ID" }`). Keep the members that map to a Postgres type — the bases the
+  // value is assignable to — and drop the markers, which don't map. Unlike a union, an
+  // unmappable member is expected here (it's a marker), so it is skipped rather than fatal.
+  const strategies: PgTypeStrategy[] = [];
+
+  for (const member of types) {
+    const result = checkType({ checker, type: member, options });
+    if (E.isRight(result) && result.right !== null) {
+      strategies.push(result.right);
+    }
+  }
+
+  if (strategies.length === 0) {
+    const typesStr = types.map((t) => checker.typeToString(t)).join(" & ");
+    return E.left(`No PostgreSQL type could be inferred for the intersection: ${typesStr}`);
+  }
+
+  const casts = [...new Set(strategies.map((strategy) => strategy.cast))];
+
+  if (casts.length > 1) {
+    return E.left(
+      `Intersection types must result in the same PostgreSQL type (found ${casts.join(", ")})`,
+    );
+  }
+
+  return E.right(strategies[0]);
+}
+
 type PgTypeStrategy =
   | { kind: "cast"; cast: string }
   | { kind: "literal"; value: string; cast: string }
@@ -481,6 +517,10 @@ function checkType(params: {
   if (override) {
     const [pgType] = override;
     return E.right({ kind: "cast", cast: isArray ? `${pgType}[]` : pgType });
+  }
+
+  if (type.isIntersection()) {
+    return getPgTypeFromTsTypeIntersection({ types: type.types, checker, options });
   }
 
   const enumType = TSUtils.getEnumKind(type);


### PR DESCRIPTION
## Problem

A branded (opaque) type such as `string & { __brand: "ID" }` is a TypeScript **intersection** of a base type and one or more marker objects. `checkType` (`ts-pg.utils.ts`) has no intersection branch, so `checker.typeToString` produces something like `ID<User>` that matches no entry in the type map and falls through to:

> The type "ID<User>" has no corresponding PostgreSQL type.

This forces every branded parameter to be cast (`${id as string}`) or registered via `overrides.types`, even though at the database level the value is just its base type. The same fall-through breaks nullable unions: `ID<User> | null` fails because `getPgTypeFromTsTypeUnion` recurses into `checkType` for the branded member.

Refs #251, #2.

## Before / After

### Minimal example (self-contained, no schema)

A branded `ID` used as a parameter.

**Before** — the branded parameter has no corresponding PostgreSQL type, so SafeQL errors:

```ts
type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };

function run(id: ID<"User">) {
  // 💥 The type "ID<"User">" has no corresponding PostgreSQL type.
  //    Please add it manually using the "overrides.types" option: ...
  conn.query(sql`SELECT ${id} AS col`);
}
```

**Workaround (before)** — coerce the value back to its base type at every call site:

```ts
function run(id: ID<"User">) {
  // ✅ works, but every branded parameter must be wrapped
  conn.query<{ col: string | null }>(sql`SELECT ${String(id)} AS col`);
}
```

**After** — the branded type resolves to its base type (`text`) automatically, no coercion needed:

```ts
function run(id: ID<"User">) {
  // ✅ no error, inferred as text
  conn.query<{ col: string | null }>(sql`SELECT ${id} AS col`);
}
```

### Real-world example (the case that motivated this PR)

An array of branded Shopify GIDs (`string & { __brand: "ID" }`, i.e. `gid://shopify/...`) passed to `UNNEST` — aliased from a production query.

**Before** — the branded array has no corresponding PostgreSQL type:

```ts
type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };

function findByExternalIds(externalIds: ID<"LineItem">[]) {
  // 💥 The type "ID<"LineItem">[]" has no corresponding PostgreSQL type.
  conn.query(sql`SELECT * FROM UNNEST(${externalIds} :: text[]) AS t(external_id)`);
}
```

**Workaround (before)** — cast the branded array to its base type:

```ts
function findByExternalIds(externalIds: ID<"LineItem">[]) {
  // ✅ works, but every branded array needs an `as string[]` cast
  conn.query<{ external_id: string }>(
    sql`SELECT * FROM UNNEST(${externalIds as string[]} :: text[]) AS t(external_id)`,
  );
}
```

**After** — the branded array resolves to `text[]`, the cast disappears:

```ts
function findByExternalIds(externalIds: ID<"LineItem">[]) {
  // ✅ no error, inferred as text[]
  conn.query<{ external_id: string }>(
    sql`SELECT * FROM UNNEST(${externalIds} :: text[]) AS t(external_id)`,
  );
}
```

## Fix

`checkType` now handles intersection types by resolving each member and keeping the ones that map to a Postgres type — the base(s) the value is assignable to — while dropping members it doesn't recognise (the markers, which exist only in TypeScript). Because array and union handling already recurse through `checkType`, a single branch covers all the cases:

- `ID<User>` → `text`
- `NumericId` (`number & {...}`) → `int`
- `ID<User>[]` → `text[]`
- `ID<User> | null` → `text`

Member order doesn't matter (`{ __brand } & string` works), and a non-primitive base is fine too (`Date & {...}` → `date`).

The branch is placed **after** the `overrides.types` lookup, so an explicit override still wins. It intentionally diverges from `getPgTypeFromTsTypeUnion` in one way: a union member that can't map is fatal, but an unmappable intersection member is *expected* (it's the marker), so it's skipped rather than aborting. Type safety is preserved — see the rejection cases below.

> **Note — before/after.** Resolution keeps the intersection members that map to a pg type and drops the rest (markers). An intersection where **two** members map (two recognised types) is **rejected**, not silently coerced.
>
> | parameter type | before | after |
> | --- | --- | --- |
> | `ID<User>` | ❌ "no corresponding PostgreSQL type" | ✅ `text` |
> | `ID<User>[]` | ❌ same error | ✅ `text[]` |
> | `ID<User> \| null` | ❌ same error | ✅ `text` |
> | `string & { ...data }` | ❌ same error | ✅ `text` (object is an unrecognised marker) |
> | `string & Date` | ❌ same error | ❌ **rejected** — two bases conflict (`text` vs `date`) |

## Tests

Added `check-sql.branded-types.test.ts`. The resolution cases select the parameter back as a column (`SELECT ${param} AS col`) so the rule's auto-fix annotation pins the **exact inferred pg type**, rather than only checking that no error is reported:

- `ID<User>` → `string`, `NumericId` → `number`, `ID<User>[]` → `string[]`
- reversed-order, multiple-marker, non-marker-object, nullable-union and nullable-array variants

Plus red-team / rejection cases asserting exact error strings:

- a branded string is still rejected against an `integer` column
- a non-branded object intersection (`{ a } & { b }`) is rejected (no base maps)
- an intersection of two conflicting bases (`string & Date`) is rejected (`text` vs `date`)

Full `eslint-plugin` suite passes (292 tests). Includes a `patch` changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branded TypeScript intersection types used as SQL query parameters now resolve to their underlying base PostgreSQL types (including arrays and nullable/union cases), while type-mismatch errors are still reported and public APIs remain unchanged.

* **Tests**
  * Expanded test coverage for branded types: single values, arrays, nullable unions, marker-order and intersection variations, and mismatch/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

