### PR TITLE
Add zod-annotator npm metadata

### DIFF
--- a/.changeset/green-spoons-wave.md
+++ b/.changeset/green-spoons-wave.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/zod-annotator": patch
+---
+
+Add npm package homepage and issue tracker metadata.

--- a/packages/zod-annotator/package.json
+++ b/packages/zod-annotator/package.json
@@ -8,6 +8,10 @@
     "url": "git+https://github.com/ts-safeql/safeql.git",
     "directory": "packages/zod-annotator"
   },
+  "homepage": "https://github.com/ts-safeql/safeql/tree/main/packages/zod-annotator",
+  "bugs": {
+    "url": "https://github.com/ts-safeql/safeql/issues"
+  },
   "files": [
     "dist",
     "package.json"


### PR DESCRIPTION
## Summary

- Add package-level homepage metadata for `@ts-safeql/zod-annotator`.
- Add package-level bugs metadata pointing npm users to the repository issues page.
- Add a patch changeset for the package metadata update.

## Why

The published npm package currently exposes repository metadata but no homepage or bugs fields, so users browsing npm do not get direct links to the package source folder or issue tracker.

## Validation

- `node -e "const p=require('./packages/zod-annotator/package.json'); if(p.homepage!=='https://github.com/ts-safeql/safeql/tree/main/packages/zod-annotator') throw new Error('homepage mismatch'); if(p.bugs?.url!=='https://github.com/ts-safeql/safeql/issues') throw new Error('bugs mismatch'); console.log('metadata smoke ok')"`
- `npm pack --dry-run --ignore-scripts ./packages/zod-annotator`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated package metadata including homepage and bug tracker information for improved discoverability
* Tagged `@ts-safeql/zod-annotator` as a patch release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->