### PR TITLE
fix: resolve tuple and template-literal types as query parameters

### DIFF
--- a/.changeset/template-literal-types-as-parameters.md
+++ b/.changeset/template-literal-types-as-parameters.md
@@ -1,0 +1,7 @@
+---
+"@ts-safeql/eslint-plugin": patch
+---
+
+Resolve template-literal types (and branded `Money`) to `text` when used as query parameters.
+
+A template-literal type such as `` `${number}` `` or `` `${string}` `` is a string at runtime but had no corresponding PostgreSQL type, so passing one as a parameter required a manual cast or an `overrides.types` entry. `checkType` now maps any template-literal type to `text` (and an array of them to `text[]`), mirroring how a plain `string` is handled. This also fixes branded `Money` (`` `${number}` & { __brand: "Money" } ``): the intersection branch resolves each member through `checkType`, and the `` `${number}` `` base now resolves to `text`, so the whole intersection maps to `text` with no change to the intersection helper. Intrinsic string-mapping types (`Uppercase<string>`, etc.) resolve to `text` as well, and an explicit `overrides.types` entry still takes precedence. Passing a template-literal value where an incompatible column type is expected is still reported, and a template-literal intersected with a conflicting base type (e.g. `` `${number}` `` & Date) is rejected.

--- a/.changeset/tuple-types-as-parameters.md
+++ b/.changeset/tuple-types-as-parameters.md
@@ -1,0 +1,7 @@
+---
+"@ts-safeql/eslint-plugin": patch
+---
+
+Resolve tuple types to their element type when used as query parameters.
+
+A tuple such as `NonEmptyArray<T>` (`[T, ...T[]]`) has no corresponding PostgreSQL type, so passing one as a parameter forced a manual `as T[]` cast, a `[...spread]`, or an `overrides.types` entry. `checkType` now resolves each element type of a tuple and, when they agree, maps the tuple to that element type's array (`T[]`) — mirroring how a real array is handled. Element resolution recurses, so branded elements like `NonEmptyArray<ID>` still map to `text[]`. An empty tuple, an all-null tuple, or a heterogeneous tuple whose elements map to conflicting PostgreSQL types is rejected, and an explicit `overrides.types` entry still takes precedence.

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.template-literal-types.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.template-literal-types.test.ts
@@ -1,0 +1,167 @@
+import { normalizeIndent } from "@ts-safeql/shared";
+import { checkSqlRule, ruleTester, setupCheckSqlRuleTester } from "./check-sql.test-utils";
+
+const { connections, withConnection } = setupCheckSqlRuleTester();
+
+ruleTester.run("template-literal types as query parameters", checkSqlRule, {
+  valid: [
+    {
+      name: "array of template-literals validates against a real text[] column",
+      options: withConnection(connections.withSkipTypeAnnotations),
+      code: normalizeIndent`
+        function run(values: \`\${number}\`[]) {
+          conn.query(sql\`INSERT INTO test_insert_array_union_literals (colname) VALUES (\${values})\`);
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "`${number}` template-literal parameter is inferred as text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        function run(value: \`\${number}\`) {
+          conn.query(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        function run(value: \`\${number}\`) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "`${string}` template-literal parameter is inferred as text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        function run(value: \`prefix-\${string}\`) {
+          conn.query(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        function run(value: \`prefix-\${string}\`) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "branded Money (`${number}` & { __brand }) is inferred as text via intersection composition",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type Money = \`\${number}\` & { readonly __brand: "Money" };
+        function run(amount: Money) {
+          conn.query(sql\`SELECT \${amount} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type Money = \`\${number}\` & { readonly __brand: "Money" };
+        function run(amount: Money) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${amount} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "array of template-literals is inferred as text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        function run(values: \`\${number}\`[]) {
+          conn.query(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        function run(values: \`\${number}\`[]) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "array of branded Money is inferred as text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type Money = \`\${number}\` & { readonly __brand: "Money" };
+        function run(amounts: Money[]) {
+          conn.query(sql\`SELECT \${amounts} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type Money = \`\${number}\` & { readonly __brand: "Money" };
+        function run(amounts: Money[]) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${amounts} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "`${number}` template-literal is still rejected against a non-text column",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        function run(value: \`\${number}\`) {
+          return sql\`INSERT INTO test_nullable_column (nullable_int) VALUES (\${value})\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: {
+            error: 'column "nullable_int" is of type integer but expression is of type text',
+          },
+        },
+      ],
+    },
+    {
+      name: "template-literal intersected with a conflicting base type is rejected",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        type Weird = \`\${number}\` & Date;
+        function run(x: Weird) {
+          return sql\`SELECT FROM member WHERE first_name = \${x}\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: {
+            error: "Intersection types must result in the same PostgreSQL type (found text, date)",
+          },
+        },
+      ],
+    },
+    {
+      name: "intrinsic string-mapping type (Uppercase<string>) is inferred as text",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        function run(value: Uppercase<string>) {
+          conn.query(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        function run(value: Uppercase<string>) {
+          conn.query<{ col: string | null }>(sql\`SELECT \${value} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "branded Money is still rejected against a non-text column",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        type Money = \`\${number}\` & { readonly __brand: "Money" };
+        function run(amount: Money) {
+          return sql\`INSERT INTO test_nullable_column (nullable_int) VALUES (\${amount})\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: {
+            error: 'column "nullable_int" is of type integer but expression is of type text',
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.tuple-types.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.tuple-types.test.ts
@@ -1,0 +1,148 @@
+import { normalizeIndent } from "@ts-safeql/shared";
+import { checkSqlRule, ruleTester, setupCheckSqlRuleTester } from "./check-sql.test-utils";
+
+const { connections, withConnection } = setupCheckSqlRuleTester();
+
+ruleTester.run("tuple types as query parameters", checkSqlRule, {
+  valid: [
+    {
+      name: "NonEmptyArray<string> tuple param validates against a text[] column",
+      options: withConnection(connections.withSkipTypeAnnotations),
+      code: normalizeIndent`
+        type NonEmptyArray<T> = [T, ...T[]];
+        function run(values: NonEmptyArray<string>) {
+          conn.query(sql\`INSERT INTO test_insert_array_union_literals (colname) VALUES (\${values})\`);
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: "NonEmptyArray<string> parameter is inferred as text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type NonEmptyArray<T> = [T, ...T[]];
+        function run(values: NonEmptyArray<string>) {
+          conn.query(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type NonEmptyArray<T> = [T, ...T[]];
+        function run(values: NonEmptyArray<string>) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "NonEmptyArray<number> parameter is inferred as int[], not text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type NonEmptyArray<T> = [T, ...T[]];
+        function run(values: NonEmptyArray<number>) {
+          conn.query(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type NonEmptyArray<T> = [T, ...T[]];
+        function run(values: NonEmptyArray<number>) {
+          conn.query<{ col: number[] | null }>(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "NonEmptyArray of branded strings is inferred as text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        type NonEmptyArray<T> = [T, ...T[]];
+        function run(ids: NonEmptyArray<ID<"User">>) {
+          conn.query(sql\`SELECT \${ids} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        type ID<T> = string & { readonly __brand: "ID"; readonly __type?: T };
+        type NonEmptyArray<T> = [T, ...T[]];
+        function run(ids: NonEmptyArray<ID<"User">>) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${ids} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "readonly tuple [string, ...string[]] is inferred as text[]",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        function run(values: readonly [string, ...string[]]) {
+          conn.query(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        function run(values: readonly [string, ...string[]]) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      name: "heterogeneous tuple [string, number] is rejected",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        function run(values: [string, number]) {
+          return sql\`SELECT FROM member WHERE first_name = \${values}\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: {
+            error: "Tuple types must result in the same PostgreSQL type (found text, int)",
+          },
+        },
+      ],
+    },
+    {
+      name: "all-null tuple [null, null] is rejected",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        function run(values: [null, null]) {
+          return sql\`SELECT FROM member WHERE first_name = \${values}\`;
+        }
+      `,
+      errors: [
+        { messageId: "invalidQuery", data: { error: "Unsupported tuple type (only null)" } },
+      ],
+    },
+    {
+      name: "empty tuple [] is rejected",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+        function run(values: []) {
+          return sql\`SELECT FROM member WHERE first_name = \${values}\`;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidQuery",
+          data: { error: "Empty tuple types have no corresponding PostgreSQL type" },
+        },
+      ],
+    },
+    {
+      name: "tuple of string arrays is inferred as text[] (not text[][])",
+      options: withConnection(connections.base),
+      code: normalizeIndent`
+        function run(values: [string[], ...string[][]]) {
+          conn.query(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      output: normalizeIndent`
+        function run(values: [string[], ...string[][]]) {
+          conn.query<{ col: string[] | null }>(sql\`SELECT \${values} AS col\`);
+        }
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/utils/ts-pg.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts-pg.utils.ts
@@ -424,6 +424,53 @@ function getPgTypeFromTsTypeIntersection(params: {
   return E.right(strategies[0]);
 }
 
+function getPgTypeFromTsTypeTuple(params: {
+  type: ts.TypeReference;
+  checker: ts.TypeChecker;
+  options: RuleOptionConnection;
+}): E.Either<string, PgTypeStrategy | null> {
+  const { type, checker, options } = params;
+
+  // A tuple (`NonEmptyArray<T>` = `[T, ...T[]]`) has no Postgres type, but its elements share one.
+  // Resolve each via `checkType` (so branded elements still map) and return it as `T[]`, like an
+  // array. An unmappable element is fatal here, unlike an intersection marker (which is skipped).
+  const elementTypes = checker.getTypeArguments(type);
+
+  if (elementTypes.length === 0) {
+    return E.left("Empty tuple types have no corresponding PostgreSQL type");
+  }
+
+  const strategies: PgTypeStrategy[] = [];
+
+  for (const elementType of elementTypes) {
+    const result = checkType({ checker, type: elementType, options });
+    if (E.isLeft(result)) {
+      return result;
+    }
+    if (result.right !== null) {
+      strategies.push(result.right);
+    }
+  }
+
+  if (strategies.length === 0) {
+    return E.left("Unsupported tuple type (only null)");
+  }
+
+  const casts = [...new Set(strategies.map((strategy) => strategy.cast))];
+
+  if (casts.length > 1) {
+    return E.left(
+      `Tuple types must result in the same PostgreSQL type (found ${casts.join(", ")})`,
+    );
+  }
+
+  const elementCast = strategies[0].cast;
+  return E.right({
+    kind: "cast",
+    cast: elementCast.endsWith("[]") ? elementCast : `${elementCast}[]`,
+  });
+}
+
 type PgTypeStrategy =
   | { kind: "cast"; cast: string }
   | { kind: "literal"; value: string; cast: string }
@@ -548,6 +595,10 @@ function checkType(params: {
         ),
       );
     }
+  }
+
+  if (TSUtils.isTsTupleType(checker, type)) {
+    return getPgTypeFromTsTypeTuple({ type, checker, options });
   }
 
   if (type.isStringLiteral()) {

--- a/packages/eslint-plugin/src/utils/ts-pg.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts-pg.utils.ts
@@ -609,6 +609,12 @@ function checkType(params: {
     return E.right({ kind: "literal", value: `${type.value}`, cast: "int" });
   }
 
+  // Template-literal types (`${number}`) and string-mapping types (`Uppercase<string>`) are strings
+  // at runtime → `text`. This also resolves branded `Money` (its `${number}` base now lands here).
+  if (type.flags & (ts.TypeFlags.TemplateLiteral | ts.TypeFlags.StringMapping)) {
+    return E.right({ kind: "cast", cast: isArray ? "text[]" : "text" });
+  }
+
   // Handle union types
   if (type.isUnion()) {
     return pipe(

--- a/packages/eslint-plugin/src/utils/ts.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts.utils.ts
@@ -16,6 +16,9 @@ export const TSUtils = {
   isTsTypeReference(type: ts.Type): type is ts.TypeReference {
     return TSUtils.isTsObjectType(type) && type.objectFlags === ts.ObjectFlags.Reference;
   },
+  isTsTupleType(checker: ts.TypeChecker, type: ts.Type): type is ts.TypeReference {
+    return checker.isTupleType(type);
+  },
   isTsArrayUnionType(
     checker: ts.TypeChecker,
     type: ts.Type,


### PR DESCRIPTION
Follow-up to #471 (branded types). That PR taught `checkType` to resolve a branded intersection to its base primitive; this one extends the same recursive resolver to the remaining TS parameter types that have no obvious PostgreSQL mapping but a well-defined one in practice: **tuples** and **template-literal types** (which also unblocks branded `Money`).

Each is a small, independent `checkType` branch; together they remove the last `as`/`[...spread]`/`overrides.types` workarounds for these shapes.

---

## 1. Tuple types (`NonEmptyArray<T>` = `[T, ...T[]]`)

```ts
function getCustomers(ids: NonEmptyArray<ID<"Customer">>) {
  return sql`SELECT * FROM customer WHERE id = ANY(${ids})`;
}
```

| | Behaviour |
|---|---|
| **Before** | ❌ `The type "NonEmptyArray<ID<"Customer">>" has no corresponding PostgreSQL type.` |
| **Before — workaround** | `ANY(${[...ids]})` or `ANY(${ids as string[]})` |
| **After** | ✅ resolves to `text[]` |

| Param type | Resolves to |
|---|---|
| `NonEmptyArray<string>` | `text[]` |
| `NonEmptyArray<number>` | `int[]` |
| `NonEmptyArray<ID>` (branded) | `text[]` |
| `readonly [string, ...string[]]` | `text[]` |
| `[string, number]` (heterogeneous) | ❌ rejected |
| `[]` / all-`null` tuple | ❌ rejected |

`getPgTypeFromTsTypeTuple` resolves every element type through `checkType` (so branded elements still reach the intersection branch), requires they agree on one PostgreSQL type, and maps the tuple to `T[]` — mirroring the array branch. An element that is itself an array is not double-bracketed (`text[]`, not `text[][]`).

## 2. Template-literal types (and branded `Money`)

```ts
type Money = `${number}` & { __brand: "Money" };
function setTotal(amount: Money) {
  return sql`UPDATE invoice SET total = ${amount}`;
}
```

| | Behaviour |
|---|---|
| **Before** | ❌ `No PostgreSQL type could be inferred for the intersection: ${number} & { __brand: "Money"; }` |
| **Before — workaround** | `${amount as string}` |
| **After** | ✅ resolves to `text` |

| Param type | Resolves to |
|---|---|
| `` `${number}` `` / `` `${string}` `` / `` `foo-${string}` `` | `text` |
| `Uppercase<string>` (intrinsic string-mapping) | `text` |
| `Money` (`` `${number}` `` & brand) | `text` (via the intersection branch) |
| `` `${number}` `` & `Date` (conflicting bases) | ❌ rejected |

A template-literal type is a string at runtime, so it maps to `text`. Because the brand resolver from #471 resolves each intersection member through `checkType`, the `` `${number}` `` base of `Money` now lands here as `text` with **no change to the intersection helper**.

---

## Type safety preserved

Both branches only *widen the inferred type*; they never suppress a real mismatch. Passing any of these where an incompatible column type is expected is still reported as a genuine Postgres error (e.g. `column "x" is of type integer but expression is of type text`).

## Tests

Following #471's bar: every resolution path is **type-pinned** via the `missingTypeAnnotations` auto-fix `output` against `connections.base`, and every `E.left` dead-end has a **one-to-one red-team case** against `connections.withTag` asserting the verbatim diagnostic (heterogeneous / empty / all-`null` tuple; `${number}`-vs-int-column; `${number}` & Date conflict; `Money`-vs-int-column; plus a pinned `Uppercase<string>` case). DB-backed suite green, no regression to the branded suite.

Two changesets (`patch`, `@ts-safeql/eslint-plugin`): `tuple-types-as-parameters` and `template-literal-types-as-parameters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tuple types (e.g., `NonEmptyArray<T>`) as query parameters, automatically resolving to PostgreSQL array types.
  * Added support for template-literal types as query parameters, mapping to PostgreSQL text types.

* **Tests**
  * Added comprehensive test coverage for tuple and template-literal type parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->