### PR TITLE
fix: RIGHT/FULL JOIN nullability for aliased base relations

### DIFF
--- a/.changeset/right-full-join-base-alias.md
+++ b/.changeset/right-full-join-base-alias.md
@@ -1,0 +1,7 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Fix `RIGHT`/`FULL JOIN` nullability when the base (left) relation is aliased.
+
+A column selected from the base relation of a `RIGHT`/`FULL JOIN` is nullable (its row may be absent when the other side has no match), and SafeQL already inferred this when the base relation had no alias. But the base relation's alias was never tracked, so `SELECT m.id FROM member m RIGHT JOIN member_team mt ON ...` incorrectly typed `m.id` as non-null. The join analysis now records the base relation's alias and matches nullability against it, so aliased and unaliased base relations behave the same.

--- a/packages/generate/src/generate/generate.joins.test.ts
+++ b/packages/generate/src/generate/generate.joins.test.ts
@@ -80,6 +80,65 @@ test("select with right join should return all cols from the other table as null
   });
 });
 
+test("select with right join and aliased base relation should return base cols as nullable", async () => {
+  await testQuery({
+    query: `
+        SELECT
+            m.id as member_id,
+            mt.id as assoc_id
+        FROM member m
+            RIGHT JOIN member_team mt ON m.id = mt.member_id
+    `,
+    expected: [
+      [
+        "member_id",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+      ["assoc_id", { kind: "type", value: "number", type: "int4" }],
+    ],
+  });
+});
+
+test("select with full join and aliased relations should return all cols as nullable", async () => {
+  await testQuery({
+    query: `
+        SELECT
+            m.id as member_id,
+            mt.id as assoc_id
+        FROM member m
+            FULL JOIN member_team mt ON m.id = mt.member_id
+    `,
+    expected: [
+      [
+        "member_id",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+      [
+        "assoc_id",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "number", type: "int4" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
 test("select with full join should return all cols as nullable", async () => {
   await testQuery({
     query: `

--- a/packages/generate/src/utils/get-relations-with-joins.test.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.test.ts
@@ -13,10 +13,13 @@ const cases: {
   expected: [
     string,
     {
-      alias: string | undefined;
-      type: LibPgQueryAST.JoinType;
-      name: string;
-    }[],
+      relAlias: string | undefined;
+      joins: {
+        alias: string | undefined;
+        type: LibPgQueryAST.JoinType;
+        name: string;
+      }[];
+    },
   ][];
 }[] = [
   {
@@ -34,7 +37,13 @@ const cases: {
         LEFT JOIN team ON member.id = team.id
     `,
     expected: [
-      ["member", [{ alias: undefined, name: "team", type: LibPgQueryAST.JoinType.JOIN_LEFT }]],
+      [
+        "member",
+        {
+          relAlias: undefined,
+          joins: [{ alias: undefined, name: "team", type: LibPgQueryAST.JoinType.JOIN_LEFT }],
+        },
+      ],
     ],
   },
   {
@@ -49,10 +58,13 @@ const cases: {
     expected: [
       [
         "member",
-        [
-          { alias: undefined, name: "member_team", type: LibPgQueryAST.JoinType.JOIN_LEFT },
-          { alias: undefined, name: "team", type: LibPgQueryAST.JoinType.JOIN_LEFT },
-        ],
+        {
+          relAlias: undefined,
+          joins: [
+            { alias: undefined, name: "member_team", type: LibPgQueryAST.JoinType.JOIN_LEFT },
+            { alias: undefined, name: "team", type: LibPgQueryAST.JoinType.JOIN_LEFT },
+          ],
+        },
       ],
     ],
   },
@@ -76,21 +88,27 @@ const cases: {
     expected: [
       [
         "a",
-        [
-          { alias: undefined, name: "w", type: LibPgQueryAST.JoinType.JOIN_FULL },
-          { alias: undefined, name: "x", type: LibPgQueryAST.JoinType.JOIN_INNER },
-          { alias: undefined, name: "y", type: LibPgQueryAST.JoinType.JOIN_LEFT },
-          { alias: undefined, name: "z", type: LibPgQueryAST.JoinType.JOIN_RIGHT },
-        ],
+        {
+          relAlias: undefined,
+          joins: [
+            { alias: undefined, name: "w", type: LibPgQueryAST.JoinType.JOIN_FULL },
+            { alias: undefined, name: "x", type: LibPgQueryAST.JoinType.JOIN_INNER },
+            { alias: undefined, name: "y", type: LibPgQueryAST.JoinType.JOIN_LEFT },
+            { alias: undefined, name: "z", type: LibPgQueryAST.JoinType.JOIN_RIGHT },
+          ],
+        },
       ],
       [
         "b",
-        [
-          { alias: undefined, name: "w", type: LibPgQueryAST.JoinType.JOIN_FULL },
-          { alias: undefined, name: "x", type: LibPgQueryAST.JoinType.JOIN_INNER },
-          { alias: undefined, name: "y", type: LibPgQueryAST.JoinType.JOIN_LEFT },
-          { alias: undefined, name: "z", type: LibPgQueryAST.JoinType.JOIN_RIGHT },
-        ],
+        {
+          relAlias: undefined,
+          joins: [
+            { alias: undefined, name: "w", type: LibPgQueryAST.JoinType.JOIN_FULL },
+            { alias: undefined, name: "x", type: LibPgQueryAST.JoinType.JOIN_INNER },
+            { alias: undefined, name: "y", type: LibPgQueryAST.JoinType.JOIN_LEFT },
+            { alias: undefined, name: "z", type: LibPgQueryAST.JoinType.JOIN_RIGHT },
+          ],
+        },
       ],
     ],
   },
@@ -105,11 +123,14 @@ const cases: {
     expected: [
       [
         "tbl",
-        [
-          { alias: undefined, name: "subselect1", type: LibPgQueryAST.JoinType.JOIN_LEFT },
-          { alias: undefined, name: "subselect2", type: LibPgQueryAST.JoinType.JOIN_LEFT },
-          { alias: undefined, name: "subselect3", type: LibPgQueryAST.JoinType.JOIN_LEFT },
-        ],
+        {
+          relAlias: undefined,
+          joins: [
+            { alias: undefined, name: "subselect1", type: LibPgQueryAST.JoinType.JOIN_LEFT },
+            { alias: undefined, name: "subselect2", type: LibPgQueryAST.JoinType.JOIN_LEFT },
+            { alias: undefined, name: "subselect3", type: LibPgQueryAST.JoinType.JOIN_LEFT },
+          ],
+        },
       ],
     ],
   },
@@ -126,7 +147,10 @@ const cases: {
     expected: [
       [
         "parent_table",
-        [{ alias: undefined, name: "latest", type: LibPgQueryAST.JoinType.JOIN_LEFT }],
+        {
+          relAlias: undefined,
+          joins: [{ alias: undefined, name: "latest", type: LibPgQueryAST.JoinType.JOIN_LEFT }],
+        },
       ],
     ],
   },
@@ -137,7 +161,13 @@ const cases: {
       CROSS JOIN json_array_elements(t.json_column) AS v
     `,
     expected: [
-      ["all_types", [{ alias: undefined, name: "v", type: LibPgQueryAST.JoinType.JOIN_INNER }]],
+      [
+        "all_types",
+        {
+          relAlias: "t",
+          joins: [{ alias: undefined, name: "v", type: LibPgQueryAST.JoinType.JOIN_INNER }],
+        },
+      ],
     ],
   },
   {
@@ -151,10 +181,13 @@ const cases: {
     expected: [
       [
         "a",
-        [
-          { alias: undefined, name: "b", type: LibPgQueryAST.JoinType.JOIN_INNER },
-          { alias: undefined, name: "c", type: LibPgQueryAST.JoinType.JOIN_INNER },
-        ],
+        {
+          relAlias: undefined,
+          joins: [
+            { alias: undefined, name: "b", type: LibPgQueryAST.JoinType.JOIN_INNER },
+            { alias: undefined, name: "c", type: LibPgQueryAST.JoinType.JOIN_INNER },
+          ],
+        },
       ],
     ],
   },

--- a/packages/generate/src/utils/get-relations-with-joins.ts
+++ b/packages/generate/src/utils/get-relations-with-joins.ts
@@ -7,7 +7,7 @@ interface Join {
   alias?: string;
 }
 
-export type RelationsWithJoinsMap = Map<string, Join[]>;
+export type RelationsWithJoinsMap = Map<string, { relAlias: string | undefined; joins: Join[] }>;
 
 export function getRelationsWithJoins(parsed: LibPgQueryAST.ParseResult): RelationsWithJoinsMap {
   const results: RelationsWithJoinsMap = new Map();
@@ -19,8 +19,8 @@ export function getRelationsWithJoins(parsed: LibPgQueryAST.ParseResult): Relati
 
   for (const fromClause of stmt.stmt.SelectStmt.fromClause) {
     if (fromClause.JoinExpr !== undefined) {
-      const { relName, joins } = recursiveTraverseJoins([], fromClause.JoinExpr);
-      results.set(relName, joins);
+      const { relName, relAlias, joins } = recursiveTraverseJoins([], fromClause.JoinExpr);
+      results.set(relName, { relAlias, joins });
     }
   }
 
@@ -44,6 +44,7 @@ function recursiveTraverseJoins(
   joinExpr: LibPgQueryAST.JoinExpr,
 ): {
   relName: string;
+  relAlias: string | undefined;
   joins: Join[];
 } {
   const joinName = recursiveGetJoinName(joinExpr);
@@ -71,15 +72,18 @@ function recursiveTraverseJoins(
     joinExpr.rarg?.RangeSubselect?.alias?.aliasname ??
     joinExpr.rarg?.RangeFunction?.alias?.aliasname;
 
+  const relAlias = joinExpr.larg?.RangeVar?.alias?.aliasname;
+
   if (relName === undefined) {
     throw new Error("relName is undefined");
   }
 
-  return { relName, joins: [join, ...joins] };
+  return { relName, relAlias, joins: [join, ...joins] };
 }
 
 export interface FlattenedRelationWithJoins {
   relName: string;
+  relAlias: string | undefined;
   alias: string | undefined;
   joinType: LibPgQueryAST.JoinType;
   joinRelName: string;
@@ -90,9 +94,15 @@ export function flattenRelationsWithJoinsMap(
 ): FlattenedRelationWithJoins[] {
   const result: FlattenedRelationWithJoins[] = [];
 
-  relationsWithJoinsMap.forEach((joins, relName) => {
+  relationsWithJoinsMap.forEach(({ relAlias, joins }, relName) => {
     joins.forEach((join) => {
-      result.push({ relName, joinType: join.type, joinRelName: join.name, alias: join.alias });
+      result.push({
+        relName,
+        relAlias,
+        joinType: join.type,
+        joinRelName: join.name,
+        alias: join.alias,
+      });
     });
   });
 
@@ -142,7 +152,9 @@ function hasNullableBaseRelation(
   relationName: string,
 ): boolean {
   return relations.some(
-    (relation) => relation.relName === relationName && isNullableBaseRelation(relation.joinType),
+    (relation) =>
+      (relation.relName === relationName || relation.relAlias === relationName) &&
+      isNullableBaseRelation(relation.joinType),
   );
 }
 


### PR DESCRIPTION
## Problem

A column selected from the **base (left) relation** of a `RIGHT`/`FULL JOIN` is nullable — its row may be absent when the other side has no match. SafeQL inferred this correctly when the base relation was unaliased, but the base relation's alias was never tracked, so:

```sql
SELECT m.id FROM member m RIGHT JOIN member_team mt ON m.id = mt.member_id
```

typed `m.id` as non-null (unsound — it's `null` for unmatched `member_team` rows).

## Fix

Track the base relation's alias in the join analysis and match nullability against the alias as well as the table name. The match is additive and still gated on `RIGHT`/`FULL`, so it can only add nullability — never produce a false `NOT NULL`.
