### PR TITLE
feat: infer NOT NULL for view columns

### DIFF
--- a/.changeset/view-column-nullability.md
+++ b/.changeset/view-column-nullability.md
@@ -2,8 +2,6 @@
 "@ts-safeql/generate": minor
 ---
 
-Infer `NOT NULL` for columns selected from views and materialized views.
+Improve view nullability typing.
 
-PostgreSQL does not propagate `NOT NULL` constraints through views — every view column reports as nullable in the catalog — so SafeQL previously typed every view column as `T | null`. SafeQL now looks *through* a view's definition: it fetches the view body via `pg_get_viewdef`, resolves each output column with the same inference used for regular queries, and upgrades a column to non-null only when its definition provably guarantees it.
-
-This covers column passthrough from `NOT NULL` base columns (including through inner joins, while the nullable side of an outer join stays nullable), aliased and qualified references, nested views (view-on-view), materialized views, expression columns such as `count(*)`, `coalesce(x, 'fallback')`, `a || b` over `NOT NULL` columns, and `CASE`, and set-operation views (`UNION`/`INTERSECT`/`EXCEPT`) where a column is treated as non-null only when every branch proves it non-null. Anything that can't be proven (function-backed system views, definitions that don't parse) keeps the conservative nullable default, so the change never produces an unsound `NOT NULL`.
+PostgreSQL reports view columns as nullable by default, so SafeQL previously over-widened many generated types. SafeQL now inspects the view definition and infers non-nullability from the actual SQL expression, while staying conservative when a view cannot be proven safely.

--- a/.changeset/view-column-nullability.md
+++ b/.changeset/view-column-nullability.md
@@ -1,0 +1,9 @@
+---
+"@ts-safeql/generate": minor
+---
+
+Infer `NOT NULL` for columns selected from views and materialized views.
+
+PostgreSQL does not propagate `NOT NULL` constraints through views — every view column reports as nullable in the catalog — so SafeQL previously typed every view column as `T | null`. SafeQL now looks *through* a view's definition: it fetches the view body via `pg_get_viewdef`, resolves each output column with the same inference used for regular queries, and upgrades a column to non-null only when its definition provably guarantees it.
+
+This covers column passthrough from `NOT NULL` base columns (including through inner joins, while the nullable side of an outer join stays nullable), aliased and qualified references, nested views (view-on-view), materialized views, expression columns such as `count(*)`, `coalesce(x, 'fallback')`, `a || b` over `NOT NULL` columns, and `CASE`, and set-operation views (`UNION`/`INTERSECT`/`EXCEPT`) where a column is treated as non-null only when every branch proves it non-null. Anything that can't be proven (function-backed system views, definitions that don't parse) keeps the conservative nullable default, so the change never produces an unsound `NOT NULL`.

--- a/demos/playground/migrations/0_define_tables.sql
+++ b/demos/playground/migrations/0_define_tables.sql
@@ -49,7 +49,7 @@ CREATE TABLE episode (
     id SERIAL PRIMARY KEY,
     title TEXT NOT NULL,
     description TEXT,
-    season_id INT REFERENCES season(id) ON DELETE CASCADE,
+    season_id INT NOT NULL REFERENCES season(id) ON DELETE CASCADE,
     episode_number INTEGER NOT NULL,
     release_date DATE,
     run_time_minutes FLOAT,

--- a/demos/playground/migrations/2_views.sql
+++ b/demos/playground/migrations/2_views.sql
@@ -1,0 +1,16 @@
+CREATE VIEW visible_members AS
+  SELECT id, name
+  FROM actor;
+
+CREATE VIEW actor_display_names AS
+  SELECT id, COALESCE(bio, 'unknown') AS display_name
+  FROM actor;
+
+CREATE VIEW actor_bio AS
+  SELECT bio
+  FROM actor;
+
+CREATE MATERIALIZED VIEW season_episode_counts AS
+  SELECT episode.season_id, COALESCE(COUNT(*), 0)::int AS episode_count
+  FROM episode
+  GROUP BY episode.season_id;

--- a/demos/playground/src/views.ts
+++ b/demos/playground/src/views.ts
@@ -1,6 +1,14 @@
 import { sql } from "./sql";
 
 async function run() {
+  try {
+    await runQueries();
+  } finally {
+    await sql.end();
+  }
+}
+
+async function runQueries() {
   const aggregateRows = await sql<{ sum: number | null }[]>`
     SELECT sum(episode_count)::int FROM season;
   `;
@@ -28,8 +36,9 @@ async function run() {
     nullableBioRows,
     materializedRows,
   });
-
-  sql.end();
 }
 
-run();
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/demos/playground/src/views.ts
+++ b/demos/playground/src/views.ts
@@ -1,0 +1,35 @@
+import { sql } from "./sql";
+
+async function run() {
+  const aggregateRows = await sql<{ sum: number | null }[]>`
+    SELECT sum(episode_count)::int FROM season;
+  `;
+
+  const actorViewRows = await sql<{ id: number; name: string }[]>`
+    SELECT id, name FROM visible_members;
+  `;
+
+  const fallbackNameRows = await sql<{ display_name: string }[]>`
+    SELECT display_name FROM actor_display_names;
+  `;
+
+  const nullableBioRows = await sql<{ bio: string | null }[]>`
+    SELECT bio FROM actor_bio;
+  `;
+
+  const materializedRows = await sql<{ episode_count: number; season_id: number }[]>`
+    SELECT episode_count, season_id FROM season_episode_counts;
+  `;
+
+  console.log({
+    aggregateRows,
+    actorViewRows,
+    fallbackNameRows,
+    nullableBioRows,
+    materializedRows,
+  });
+
+  sql.end();
+}
+
+run();

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -9,7 +9,7 @@ import {
   isTuple,
 } from "./ast-decribe.utils";
 import { ResolvedColumn, SourcesResolver, getSources } from "./ast-get-sources";
-import { PgColRow, PgEnumsMaps, PgTypesMap } from "./generate";
+import { PgColRow, PgEnumsMaps, PgTypesMap, PgViewsBySchemaAndName } from "./generate";
 import { getNonNullableColumns, getOutputColumnKey } from "./utils/get-nonnullable-columns";
 import {
   FlattenedRelationWithJoins,
@@ -24,6 +24,7 @@ type ASTDescriptionOptions = {
   typeExprMap: Map<string, Map<string, Map<string, string>>>;
   overridenColumnTypesMap: Map<string, Map<string, string>>;
   pgColsBySchemaAndTableName: Map<string, Map<string, PgColRow[]>>;
+  pgViewsBySchemaAndName: PgViewsBySchemaAndName;
   pgTypes: PgTypesMap;
   pgEnums: PgEnumsMaps;
   pgFns: Map<string, { ts: string; pg: string }>;
@@ -116,6 +117,8 @@ export function getASTDescription(params: ASTDescriptionOptions): {
       prevSources: params.prevSources,
       nonNullableColumns: nonNullableColumns,
       pgColsBySchemaAndTableName: params.pgColsBySchemaAndTableName,
+      pgViewsBySchemaAndName: params.pgViewsBySchemaAndName,
+      pgAggregateNames: params.pgAggregateNames,
     }),
     select: select,
     resolved: new WeakMap(),
@@ -644,6 +647,7 @@ function getDescribedSelectStmt({
     typeExprMap: context.typeExprMap,
     overridenColumnTypesMap: context.overridenColumnTypesMap,
     pgColsBySchemaAndTableName: context.pgColsBySchemaAndTableName,
+    pgViewsBySchemaAndName: context.pgViewsBySchemaAndName,
     pgTypes: context.pgTypes,
     pgEnums: context.pgEnums,
     pgFns: context.pgFns,
@@ -1405,6 +1409,7 @@ function getDescribedColumnsFromSelect(params: {
     typeExprMap: params.context.typeExprMap,
     overridenColumnTypesMap: params.context.overridenColumnTypesMap,
     pgColsBySchemaAndTableName: params.context.pgColsBySchemaAndTableName,
+    pgViewsBySchemaAndName: params.context.pgViewsBySchemaAndName,
     pgTypes: params.context.pgTypes,
     pgEnums: params.context.pgEnums,
     pgFns: params.context.pgFns,

--- a/packages/generate/src/ast-get-sources.test.ts
+++ b/packages/generate/src/ast-get-sources.test.ts
@@ -26,6 +26,8 @@ describe("getSources", () => {
       relations,
       nonNullableColumns: new Set<string>(),
       pgColsBySchemaAndTableName,
+      pgViewsBySchemaAndName: new Map(),
+      pgAggregateNames: new Set<string>(),
     });
 
     const prevSources = new Map([
@@ -38,6 +40,8 @@ describe("getSources", () => {
       prevSources,
       nonNullableColumns: new Set<string>(),
       pgColsBySchemaAndTableName,
+      pgViewsBySchemaAndName: new Map(),
+      pgAggregateNames: new Set<string>(),
     });
 
     expect(resolver.sources.get("foo")?.kind).toBe("subselect");

--- a/packages/generate/src/ast-get-sources.ts
+++ b/packages/generate/src/ast-get-sources.ts
@@ -1,7 +1,10 @@
 import * as LibPgQueryAST from "@ts-safeql/sql-ast";
-import { PgColRow } from "./generate";
+import { PgColRow, PgViewsBySchemaAndName } from "./generate";
+import { getNonNullableColumns, isColumnNonNullable } from "./utils/get-nonnullable-columns";
 import {
   FlattenedRelationWithJoins,
+  flattenRelationsWithJoinsMap,
+  getRelationsWithJoins,
   isRelationNullableDueToJoin,
 } from "./utils/get-relations-with-joins";
 
@@ -19,6 +22,14 @@ type TableSelectSource = {
   original: string;
   alias?: string;
   columns: Map<string, ResolvedColumn>;
+  /**
+   * For views only: the set of output column names that the view's definition
+   * proves non-null (e.g. they pass through a NOT NULL base column from a
+   * non-nullable side of a join). PostgreSQL reports all view columns as
+   * nullable, so this lets us *upgrade* them without ever risking an unsound
+   * NOT NULL — anything we can't prove keeps its conservative nullable default.
+   */
+  nonNullableViewColumns?: Set<string>;
 };
 
 type CteSubselectSource = {
@@ -38,7 +49,14 @@ type SourcesOptions = {
   prevSources?: Map<string, SelectSource>;
   nonNullableColumns: Set<string>;
   pgColsBySchemaAndTableName: Map<string, Map<string, PgColRow[]>>;
+  pgViewsBySchemaAndName: PgViewsBySchemaAndName;
+  pgAggregateNames: Set<string>;
   relations: FlattenedRelationWithJoins[];
+  /**
+   * Schema-qualified names of views currently being expanded, used to guard
+   * against self-referential / recursive views looping forever.
+   */
+  visitedViews?: Set<string>;
 };
 
 export function getSources({
@@ -46,7 +64,10 @@ export function getSources({
   prevSources,
   nonNullableColumns,
   pgColsBySchemaAndTableName,
+  pgViewsBySchemaAndName,
+  pgAggregateNames,
   relations,
+  visitedViews,
 }: SourcesOptions) {
   const tableToSchema = new Map<string, string>();
 
@@ -77,9 +98,12 @@ export function getSources({
 
       const resolver = getSources({
         pgColsBySchemaAndTableName,
+        pgViewsBySchemaAndName,
+        pgAggregateNames,
         prevSources,
         nonNullableColumns,
         relations,
+        visitedViews,
         select: cte.CommonTableExpr.ctequery.SelectStmt,
       });
 
@@ -143,6 +167,10 @@ export function getSources({
         name: tableName,
         alias: node.RangeVar.alias?.aliasname,
         columns: new Map(),
+        // If this relation is a view, look *through* its definition to recover
+        // which of its (catalog-nullable) columns are actually non-null. Falls
+        // back to plain table resolution for non-views and unanalyzable views.
+        nonNullableViewColumns: getNonNullableViewColumns({ schemaName, viewName: realTableName }),
       };
 
       for (const col of tableColsArray) {
@@ -174,7 +202,10 @@ export function getSources({
         sources: getSources({
           nonNullableColumns,
           pgColsBySchemaAndTableName,
+          pgViewsBySchemaAndName,
+          pgAggregateNames,
           relations,
+          visitedViews,
           prevSources: combinedPrevSources,
           select: node.RangeSubselect.subquery.SelectStmt,
         }),
@@ -409,9 +440,152 @@ export function getSources({
       nonNullableColumns.has(col.colName) ||
       nonNullableColumns.has(`${source.name}.${col.colName}`);
     const isNotNullInTable = col.colNotNull;
-    const isNonNullable = isNotNullBasedOnAST || (isNotNullInTable && !isNullableDueToRelation);
+    const isNotNullInView = source.nonNullableViewColumns?.has(col.colName) ?? false;
+    const isNonNullable =
+      isNotNullBasedOnAST || ((isNotNullInTable || isNotNullInView) && !isNullableDueToRelation);
 
     return { column: col, isNotNull: isNonNullable };
+  }
+
+  /**
+   * Looks through a view's definition to find which of its output columns are
+   * provably non-null, using the same inference applied to any query so it
+   * honors base-table NOT NULL, joins, WHERE IS NOT NULL, expressions, set
+   * operations, and nested views. Anything it cannot prove (function sources,
+   * unparseable bodies, ...) keeps PostgreSQL's conservative nullable default,
+   * so it never produces an unsound NOT NULL.
+   */
+  function getNonNullableViewColumns(params: {
+    schemaName: string;
+    viewName: string;
+  }): Set<string> | undefined {
+    const viewSelect = pgViewsBySchemaAndName.get(params.schemaName)?.get(params.viewName);
+
+    if (viewSelect === undefined) {
+      return undefined;
+    }
+
+    const viewKey = `${params.schemaName}.${params.viewName}`;
+
+    if (visitedViews?.has(viewKey)) {
+      return undefined;
+    }
+
+    const childVisited = new Set([...(visitedViews ?? []), viewKey]);
+    const nonNullable = new Set<string>();
+
+    for (const { name, isNotNull } of analyzeSelectNonNull(viewSelect, childVisited)) {
+      if (isNotNull && name !== undefined) {
+        nonNullable.add(name);
+      }
+    }
+
+    return nonNullable;
+  }
+
+  /**
+   * Per-output-column non-null analysis of a view body. Set operations are
+   * combined by position: a column is non-null only when every branch proves it
+   * non-null (sound for UNION/INTERSECT/EXCEPT, conservative for the latter two).
+   * Output names come from the leftmost branch, matching PostgreSQL.
+   */
+  function analyzeSelectNonNull(
+    select: LibPgQueryAST.SelectStmt,
+    visited: Set<string>,
+  ): { name: string | undefined; isNotNull: boolean }[] {
+    const { op, larg, rarg } = select;
+
+    if (
+      op !== undefined &&
+      op !== LibPgQueryAST.SetOperation.SETOP_NONE &&
+      larg !== undefined &&
+      rarg !== undefined
+    ) {
+      const left = analyzeSelectNonNull(larg, visited);
+      const right = analyzeSelectNonNull(rarg, visited);
+
+      return left.map((column, index) => ({
+        name: column.name,
+        isNotNull: column.isNotNull && (right[index]?.isNotNull ?? false),
+      }));
+    }
+
+    return analyzePlainSelectNonNull(select, visited);
+  }
+
+  function analyzePlainSelectNonNull(
+    select: LibPgQueryAST.SelectStmt,
+    visited: Set<string>,
+  ): { name: string | undefined; isNotNull: boolean }[] {
+    const parsed: LibPgQueryAST.ParseResult = {
+      version: 0,
+      stmts: [{ stmt: { SelectStmt: select }, stmtLocation: 0, stmtLen: 0 }],
+    };
+
+    const resolver = getSources({
+      pgColsBySchemaAndTableName,
+      pgViewsBySchemaAndName,
+      pgAggregateNames,
+      select,
+      prevSources: undefined,
+      nonNullableColumns: getNonNullableColumns(parsed, { aggregateNames: pgAggregateNames }),
+      relations: flattenRelationsWithJoinsMap(getRelationsWithJoins(parsed)),
+      visitedViews: visited,
+    });
+
+    // Backs the expression analyzer with this branch's own source nullability
+    // (base-table NOT NULL, join nullability, nested views) — knowledge it
+    // cannot derive from the expression structure alone.
+    const resolveColumnRefNonNull = (columnRef: LibPgQueryAST.ColumnRef): boolean => {
+      const fields = columnRef.fields ?? [];
+      const names = fields.map((f) => f.String?.sval).filter((s): s is string => s !== undefined);
+
+      if (names.length === 0 || names.length !== fields.length) {
+        return false;
+      }
+
+      const resolved =
+        names.length === 1
+          ? resolver.getNestedResolvedTargetField({ kind: "unknown", field: names[0] })
+          : resolver.getNestedResolvedTargetField({
+              kind: "column",
+              table: names[names.length - 2],
+              column: names[names.length - 1],
+            });
+
+      return resolved?.isNotNull ?? false;
+    };
+
+    return (select.targetList ?? []).map((target) => {
+      const resTarget = target.ResTarget;
+
+      if (resTarget === undefined) {
+        return { name: undefined, isNotNull: false };
+      }
+
+      const columnRef = resTarget.val?.ColumnRef;
+
+      if (columnRef !== undefined) {
+        const names = (columnRef.fields ?? [])
+          .map((f) => f.String?.sval)
+          .filter((s): s is string => s !== undefined);
+
+        return {
+          name: resTarget.name ?? names[names.length - 1],
+          isNotNull: resolveColumnRefNonNull(columnRef),
+        };
+      }
+
+      return {
+        name: resTarget.name,
+        isNotNull: isColumnNonNullable(
+          resTarget.val,
+          parsed,
+          pgAggregateNames,
+          resolveColumnRefNonNull,
+        ),
+      };
+    });
   }
 
   return {

--- a/packages/generate/src/ast-get-sources.ts
+++ b/packages/generate/src/ast-get-sources.ts
@@ -1,6 +1,10 @@
 import * as LibPgQueryAST from "@ts-safeql/sql-ast";
 import { PgColRow, PgViewsBySchemaAndName } from "./generate";
-import { getNonNullableColumns, isColumnNonNullable } from "./utils/get-nonnullable-columns";
+import {
+  getNonNullableColumns,
+  getOutputColumnKey,
+  isColumnNonNullable,
+} from "./utils/get-nonnullable-columns";
 import {
   FlattenedRelationWithJoins,
   flattenRelationsWithJoinsMap,
@@ -22,13 +26,6 @@ type TableSelectSource = {
   original: string;
   alias?: string;
   columns: Map<string, ResolvedColumn>;
-  /**
-   * For views only: the set of output column names that the view's definition
-   * proves non-null (e.g. they pass through a NOT NULL base column from a
-   * non-nullable side of a join). PostgreSQL reports all view columns as
-   * nullable, so this lets us *upgrade* them without ever risking an unsound
-   * NOT NULL — anything we can't prove keeps its conservative nullable default.
-   */
   nonNullableViewColumns?: Set<string>;
 };
 
@@ -52,10 +49,6 @@ type SourcesOptions = {
   pgViewsBySchemaAndName: PgViewsBySchemaAndName;
   pgAggregateNames: Set<string>;
   relations: FlattenedRelationWithJoins[];
-  /**
-   * Schema-qualified names of views currently being expanded, used to guard
-   * against self-referential / recursive views looping forever.
-   */
   visitedViews?: Set<string>;
 };
 
@@ -69,6 +62,8 @@ export function getSources({
   relations,
   visitedViews,
 }: SourcesOptions) {
+  const nonNullableViewColumnsCache = new Map<string, Set<string> | undefined>();
+
   const tableToSchema = new Map<string, string>();
 
   const publicCols = pgColsBySchemaAndTableName.get("public");
@@ -167,9 +162,6 @@ export function getSources({
         name: tableName,
         alias: node.RangeVar.alias?.aliasname,
         columns: new Map(),
-        // If this relation is a view, look *through* its definition to recover
-        // which of its (catalog-nullable) columns are actually non-null. Falls
-        // back to plain table resolution for non-views and unanalyzable views.
         nonNullableViewColumns: getNonNullableViewColumns({ schemaName, viewName: realTableName }),
       };
 
@@ -447,27 +439,14 @@ export function getSources({
     return { column: col, isNotNull: isNonNullable };
   }
 
-  /**
-   * Looks through a view's definition to find which of its output columns are
-   * provably non-null, using the same inference applied to any query so it
-   * honors base-table NOT NULL, joins, WHERE IS NOT NULL, expressions, set
-   * operations, and nested views. Anything it cannot prove (function sources,
-   * unparseable bodies, ...) keeps PostgreSQL's conservative nullable default,
-   * so it never produces an unsound NOT NULL.
-   */
-  function getNonNullableViewColumns(params: {
-    schemaName: string;
-    viewName: string;
-  }): Set<string> | undefined {
-    const viewSelect = pgViewsBySchemaAndName.get(params.schemaName)?.get(params.viewName);
+  function computeNonNullableViewColumns(
+    viewKey: string,
+    schemaName: string,
+    viewName: string,
+  ): Set<string> | undefined {
+    const viewSelect = pgViewsBySchemaAndName.get(schemaName)?.get(viewName);
 
-    if (viewSelect === undefined) {
-      return undefined;
-    }
-
-    const viewKey = `${params.schemaName}.${params.viewName}`;
-
-    if (visitedViews?.has(viewKey)) {
+    if (viewSelect === undefined || visitedViews?.has(viewKey)) {
       return undefined;
     }
 
@@ -483,11 +462,25 @@ export function getSources({
     return nonNullable;
   }
 
+  function getNonNullableViewColumns(params: {
+    schemaName: string;
+    viewName: string;
+  }): Set<string> | undefined {
+    const viewKey = `${params.schemaName}.${params.viewName}`;
+
+    if (nonNullableViewColumnsCache.has(viewKey)) {
+      return nonNullableViewColumnsCache.get(viewKey);
+    }
+
+    const result = computeNonNullableViewColumns(viewKey, params.schemaName, params.viewName);
+    nonNullableViewColumnsCache.set(viewKey, result);
+    return result;
+  }
+
   /**
-   * Per-output-column non-null analysis of a view body. Set operations are
-   * combined by position: a column is non-null only when every branch proves it
-   * non-null (sound for UNION/INTERSECT/EXCEPT, conservative for the latter two).
-   * Output names come from the leftmost branch, matching PostgreSQL.
+   * Per-column non-null analysis of a view body. A set-operation column is non-null
+   * only if every branch proves it (sound for UNION/INTERSECT, conservative for EXCEPT);
+   * output names come from the leftmost branch, matching PostgreSQL.
    */
   function analyzeSelectNonNull(
     select: LibPgQueryAST.SelectStmt,
@@ -533,9 +526,6 @@ export function getSources({
       visitedViews: visited,
     });
 
-    // Backs the expression analyzer with this branch's own source nullability
-    // (base-table NOT NULL, join nullability, nested views) — knowledge it
-    // cannot derive from the expression structure alone.
     const resolveColumnRefNonNull = (columnRef: LibPgQueryAST.ColumnRef): boolean => {
       const fields = columnRef.fields ?? [];
       const names = fields.map((f) => f.String?.sval).filter((s): s is string => s !== undefined);
@@ -577,13 +567,13 @@ export function getSources({
       }
 
       return {
-        name: resTarget.name,
-        isNotNull: isColumnNonNullable(
-          resTarget.val,
-          parsed,
-          pgAggregateNames,
+        name: getOutputColumnKey(resTarget.name, resTarget.val),
+        isNotNull: isColumnNonNullable({
+          val: resTarget.val,
+          root: parsed,
+          aggregateNames: pgAggregateNames,
           resolveColumnRefNonNull,
-        ),
+        }),
       };
     });
   }

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -9,6 +9,7 @@ import {
   QuerySourceMapEntry,
   toCase,
 } from "@ts-safeql/shared";
+import * as LibPgQueryAST from "@ts-safeql/sql-ast";
 import { either } from "fp-ts";
 import * as parser from "libpg-query";
 import postgres from "postgres";
@@ -72,6 +73,7 @@ type Cache = {
       pgEnums: PgEnumsMaps;
       pgColsByTableOidCache: Map<number, PgColRow[]>;
       pgColsBySchemaAndTableName: Map<string, Map<string, PgColRow[]>>;
+      pgViewsBySchemaAndName: PgViewsBySchemaAndName;
       pgFnsByName: Map<string, PgFnRow[]>;
       pgAggregateNames: Set<string>;
       pgTypeExprMap: Map<string, Map<string, Map<string, string>>>;
@@ -129,6 +131,7 @@ async function generate(
   const {
     pgColsByTableOidCache,
     pgColsBySchemaAndTableName,
+    pgViewsBySchemaAndName,
     pgTypes,
     pgEnums,
     pgFnsByName,
@@ -277,6 +280,7 @@ async function generate(
       typesMap: typesMap,
       overridenColumnTypesMap: overridenColumnTypesMap,
       pgColsBySchemaAndTableName: pgColsBySchemaAndTableName,
+      pgViewsBySchemaAndName: pgViewsBySchemaAndName,
       pgTypes: pgTypes,
       pgEnums: pgEnums,
       pgFns: functionsMap,
@@ -346,6 +350,7 @@ async function getDatabaseMetadata(sql: Sql) {
   const pgAggregateNames = await getPgAggregateFunctionNames(sql);
   const pgColsByTableOidCache = groupBy(pgCols, "tableOid");
   const pgColsBySchemaAndTableName = groupBy(pgCols, "schemaName", "tableName");
+  const pgViewsBySchemaAndName = await getPgViews(sql);
   const pgFnsByName = groupBy(pgFns, "name");
   const pgTypeExprMap = await getPgTypeExprMap(sql);
 
@@ -355,10 +360,65 @@ async function getDatabaseMetadata(sql: Sql) {
     pgEnums,
     pgColsByTableOidCache,
     pgColsBySchemaAndTableName,
+    pgViewsBySchemaAndName,
     pgFnsByName,
     pgAggregateNames,
     pgTypeExprMap,
   };
+}
+
+/**
+ * PostgreSQL does not propagate NOT NULL constraints through views — every view
+ * column reports `attnotnull = false` regardless of its underlying source column.
+ * To recover nullability we look *through* the view: fetch each view/matview's
+ * definition, parse it, and resolve its output columns against their underlying
+ * sources to learn which are provably non-null (see ast-get-sources).
+ */
+export type PgViewsBySchemaAndName = Map<string, Map<string, LibPgQueryAST.SelectStmt>>;
+
+interface PgViewRow {
+  schemaName: string;
+  viewName: string;
+  definition: string;
+}
+
+async function getPgViews(sql: Sql): Promise<PgViewsBySchemaAndName> {
+  const rows = await sql<PgViewRow[]>`
+      SELECT
+          pg_namespace.nspname AS "schemaName",
+          pg_class.relname AS "viewName",
+          pg_get_viewdef(pg_class.oid) AS "definition"
+      FROM
+          pg_class
+          JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+      WHERE
+          pg_class.relkind IN ('v', 'm')
+  `;
+
+  const map: PgViewsBySchemaAndName = new Map();
+
+  for (const row of rows) {
+    let select: LibPgQueryAST.SelectStmt | undefined;
+
+    try {
+      const parsed = await parser.parse(row.definition);
+      select = parsed.stmts[0]?.stmt?.SelectStmt;
+    } catch {
+      // An unparseable definition is left out of the map so its columns keep the
+      // conservative nullable default rather than producing an unsound NOT NULL.
+      select = undefined;
+    }
+
+    if (select === undefined) {
+      continue;
+    }
+
+    const schemaViews = map.get(row.schemaName) ?? new Map<string, LibPgQueryAST.SelectStmt>();
+    schemaViews.set(row.viewName, select);
+    map.set(row.schemaName, schemaViews);
+  }
+
+  return map;
 }
 
 type ColumnAnalysisResult = {

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -368,11 +368,9 @@ async function getDatabaseMetadata(sql: Sql) {
 }
 
 /**
- * PostgreSQL does not propagate NOT NULL constraints through views — every view
- * column reports `attnotnull = false` regardless of its underlying source column.
- * To recover nullability we look *through* the view: fetch each view/matview's
- * definition, parse it, and resolve its output columns against their underlying
- * sources to learn which are provably non-null (see ast-get-sources).
+ * Parsed view/matview bodies, keyed by schema then view name. PostgreSQL reports every
+ * view column as nullable, so we look through these definitions to recover non-nullability
+ * (see ast-get-sources).
  */
 export type PgViewsBySchemaAndName = Map<string, Map<string, LibPgQueryAST.SelectStmt>>;
 
@@ -393,22 +391,16 @@ async function getPgViews(sql: Sql): Promise<PgViewsBySchemaAndName> {
           JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
       WHERE
           pg_class.relkind IN ('v', 'm')
+          AND pg_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
   `;
+
+  const parsedRows = await Promise.all(
+    rows.map(async (row) => ({ row, select: await parseViewSelect(row.definition) })),
+  );
 
   const map: PgViewsBySchemaAndName = new Map();
 
-  for (const row of rows) {
-    let select: LibPgQueryAST.SelectStmt | undefined;
-
-    try {
-      const parsed = await parser.parse(row.definition);
-      select = parsed.stmts[0]?.stmt?.SelectStmt;
-    } catch {
-      // An unparseable definition is left out of the map so its columns keep the
-      // conservative nullable default rather than producing an unsound NOT NULL.
-      select = undefined;
-    }
-
+  for (const { row, select } of parsedRows) {
     if (select === undefined) {
       continue;
     }
@@ -419,6 +411,14 @@ async function getPgViews(sql: Sql): Promise<PgViewsBySchemaAndName> {
   }
 
   return map;
+}
+
+// Unparseable definitions resolve to `undefined`, leaving their columns nullable.
+function parseViewSelect(definition: string): Promise<LibPgQueryAST.SelectStmt | undefined> {
+  return parser
+    .parse(definition)
+    .then((parsed) => parsed.stmts[0]?.stmt?.SelectStmt)
+    .catch(() => undefined);
 }
 
 type ColumnAnalysisResult = {

--- a/packages/generate/src/generate/generate.views.test.ts
+++ b/packages/generate/src/generate/generate.views.test.ts
@@ -1,0 +1,166 @@
+import { test } from "vitest";
+import { ResolvedTarget } from "../generate";
+import { setupGenerateTest } from "./generate.test-setup";
+
+const testQuery = setupGenerateTest();
+
+const int4: ResolvedTarget = { kind: "type", value: "number", type: "int4" };
+const text: ResolvedTarget = { kind: "type", value: "string", type: "text" };
+const nullable = (value: ResolvedTarget): ResolvedTarget => ({
+  kind: "union",
+  value: [value, { kind: "type", value: "null", type: "null" }],
+});
+
+test("select NOT NULL column from a view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_member AS SELECT id, first_name FROM member`,
+    query: `SELECT id, first_name FROM v_member`,
+    expected: [
+      ["id", int4],
+      ["first_name", text],
+    ],
+  });
+});
+
+test("select nullable column from a view should remain nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_nullable AS SELECT nullable_col FROM test_nullability`,
+    query: `SELECT nullable_col FROM v_nullable`,
+    expected: [["nullable_col", nullable(text)]],
+  });
+});
+
+test("select aliased NOT NULL column from a view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_member AS SELECT id AS member_id FROM member`,
+    query: `SELECT member_id FROM v_member`,
+    expected: [["member_id", int4]],
+  });
+});
+
+test("view with LEFT JOIN should keep the inner side non-null and outer side nullable", async () => {
+  await testQuery({
+    schema: `
+      CREATE VIEW v_join AS
+        SELECT m.id AS mid, mt.team_id AS tid
+        FROM member m
+        LEFT JOIN member_team mt ON mt.member_id = m.id
+    `,
+    query: `SELECT mid, tid FROM v_join`,
+    expected: [
+      ["mid", int4],
+      ["tid", nullable(int4)],
+    ],
+  });
+});
+
+test("select NOT NULL column from a nested view (view on view) should be non-nullable", async () => {
+  await testQuery({
+    schema: `
+      CREATE VIEW v_inner AS SELECT id FROM member;
+      CREATE VIEW v_outer AS SELECT id FROM v_inner;
+    `,
+    query: `SELECT id FROM v_outer`,
+    expected: [["id", int4]],
+  });
+});
+
+test("select qualified NOT NULL column from a view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_member AS SELECT id, first_name FROM member`,
+    query: `SELECT v.id, v.first_name FROM v_member v`,
+    expected: [
+      ["id", int4],
+      ["first_name", text],
+    ],
+  });
+});
+
+test("select qualified aliased NOT NULL column from a view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_member AS SELECT id AS member_id FROM member`,
+    query: `SELECT v.member_id FROM v_member v`,
+    expected: [["member_id", int4]],
+  });
+});
+
+test("select NOT NULL column from a materialized view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE MATERIALIZED VIEW mv_member AS SELECT id FROM member`,
+    query: `SELECT id FROM mv_member`,
+    expected: [["id", int4]],
+  });
+});
+
+const int8 = { kind: "type", value: "string", type: "int8" } satisfies ResolvedTarget;
+
+test("select a non-null function expression from a view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_count AS SELECT count(*) AS n FROM member`,
+    query: `SELECT n FROM v_count`,
+    expected: [["n", int8]],
+  });
+});
+
+test("select a concatenation of NOT NULL columns from a view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_name AS SELECT first_name || last_name AS full_name FROM member`,
+    query: `SELECT full_name FROM v_name`,
+    expected: [["full_name", text]],
+  });
+});
+
+test("select coalesce with a non-null fallback from a view should be non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_coalesce AS SELECT coalesce(nullable_col, 'x') AS c FROM test_nullability`,
+    query: `SELECT c FROM v_coalesce`,
+    expected: [["c", text]],
+  });
+});
+
+test("select a genuinely nullable expression from a view should remain nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_maybe AS SELECT nullif(first_name, 'x') AS maybe FROM member`,
+    query: `SELECT maybe FROM v_maybe`,
+    expected: [["maybe", nullable(text)]],
+  });
+});
+
+test("UNION view should be non-nullable when both branches are non-null", async () => {
+  await testQuery({
+    schema: `
+      CREATE VIEW v_union AS
+        SELECT id FROM member
+        UNION
+        SELECT team_id FROM member_team
+    `,
+    query: `SELECT id FROM v_union`,
+    expected: [["id", int4]],
+  });
+});
+
+test("UNION view should be nullable when one branch is nullable", async () => {
+  await testQuery({
+    schema: `
+      CREATE VIEW v_union_mixed AS
+        SELECT first_name FROM member
+        UNION
+        SELECT nullable_col FROM test_nullability
+    `,
+    query: `SELECT first_name FROM v_union_mixed`,
+    expected: [["first_name", nullable(text)]],
+  });
+});
+
+test("UNION view should infer non-null expression columns across branches", async () => {
+  await testQuery({
+    schema: `
+      CREATE VIEW v_union_count AS
+        SELECT count(*) AS n FROM member
+        UNION ALL
+        SELECT count(*) FROM member_team
+    `,
+    query: `SELECT n FROM v_union_count`,
+    expected: [["n", int8]],
+  });
+});

--- a/packages/generate/src/generate/generate.views.test.ts
+++ b/packages/generate/src/generate/generate.views.test.ts
@@ -38,6 +38,14 @@ test("select aliased NOT NULL column from a view should be non-nullable", async 
   });
 });
 
+test("view with an unaliased NOT NULL expression should keep its derived name non-nullable", async () => {
+  await testQuery({
+    schema: `CREATE VIEW v_count AS SELECT count(*) FROM member`,
+    query: `SELECT count FROM v_count`,
+    expected: [["count", { kind: "type", value: "string", type: "int8" }]],
+  });
+});
+
 test("view with LEFT JOIN should keep the inner side non-null and outer side nullable", async () => {
   await testQuery({
     schema: `

--- a/packages/generate/src/utils/get-nonnullable-columns.test.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.test.ts
@@ -32,6 +32,7 @@ const cases: {
   { query: `SELECT 10 - 2`, expected: ["?column?"] },
   { query: `SELECT 10 + 2`, expected: ["?column?"] },
   { query: `SELECT CASE WHEN true THEN 1 ELSE 0 END`, expected: ["case"] },
+  { query: `SELECT CASE WHEN true THEN 1 END`, expected: [] },
   { query: `SELECT tbl.col LIKE 'abc%' AS col_like FROM tbl`, expected: ["col_like"] },
   { query: `SELECT tbl.col NOT LIKE 'abc%' AS col_not_like FROM tbl`, expected: ["col_not_like"] },
   { query: `SELECT CASE WHEN 1 = 1 THEN 1 ELSE 0 END`, expected: ["case"] },

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -77,10 +77,18 @@ function concatStringNodes(nodes: LibPgQueryAST.Node[] | undefined): string {
   );
 }
 
-function isColumnNonNullable(
+/**
+ * `resolveColumnRefNonNull` lets a caller answer whether a bare column reference
+ * is non-null using knowledge this function lacks on its own (e.g. a view body's
+ * base-table NOT NULL constraints). When provided, it is consulted for ColumnRef
+ * nodes so expression columns like `a || b` over NOT NULL columns are inferred
+ * non-null. It is threaded through the recursion so it applies to nested operands.
+ */
+export function isColumnNonNullable(
   val: LibPgQueryAST.Node | undefined,
   root: LibPgQueryAST.ParseResult,
   aggregateNames: Set<string> | undefined,
+  resolveColumnRefNonNull?: (columnRef: LibPgQueryAST.ColumnRef) => boolean,
 ): boolean {
   if (val === undefined) {
     return false;
@@ -104,7 +112,7 @@ function isColumnNonNullable(
   }
 
   if (val.TypeCast?.arg) {
-    return isColumnNonNullable(val.TypeCast.arg, root, aggregateNames);
+    return isColumnNonNullable(val.TypeCast.arg, root, aggregateNames, resolveColumnRefNonNull);
   }
 
   if (val.SubLink) {
@@ -157,21 +165,23 @@ function isColumnNonNullable(
 
   if (val.A_Expr?.kind === LibPgQueryAST.AExprKind.AEXPR_OP) {
     return (
-      isColumnNonNullable(val.A_Expr.lexpr, root, aggregateNames) &&
-      isColumnNonNullable(val.A_Expr.rexpr, root, aggregateNames)
+      isColumnNonNullable(val.A_Expr.lexpr, root, aggregateNames, resolveColumnRefNonNull) &&
+      isColumnNonNullable(val.A_Expr.rexpr, root, aggregateNames, resolveColumnRefNonNull)
     );
   }
 
   if (val.CaseExpr) {
     for (const when of val.CaseExpr.args) {
-      if (!isColumnNonNullable(when.CaseWhen?.result, root, aggregateNames)) {
+      if (
+        !isColumnNonNullable(when.CaseWhen?.result, root, aggregateNames, resolveColumnRefNonNull)
+      ) {
         return false;
       }
     }
 
     if (
       val.CaseExpr.defresult &&
-      !isColumnNonNullable(val.CaseExpr.defresult, root, aggregateNames)
+      !isColumnNonNullable(val.CaseExpr.defresult, root, aggregateNames, resolveColumnRefNonNull)
     ) {
       return false;
     }
@@ -180,6 +190,10 @@ function isColumnNonNullable(
   }
 
   if (val.ColumnRef) {
+    if (resolveColumnRefNonNull?.(val.ColumnRef)) {
+      return true;
+    }
+
     const refColumnName = concatStringNodes(val.ColumnRef.fields);
 
     for (const stmt of root.stmts) {
@@ -201,7 +215,7 @@ function isColumnNonNullable(
 
   if (val.CoalesceExpr) {
     for (const arg of val.CoalesceExpr.args) {
-      if (isColumnNonNullable(arg, root, aggregateNames)) {
+      if (isColumnNonNullable(arg, root, aggregateNames, resolveColumnRefNonNull)) {
         return true;
       }
     }

--- a/packages/generate/src/utils/get-nonnullable-columns.ts
+++ b/packages/generate/src/utils/get-nonnullable-columns.ts
@@ -78,18 +78,17 @@ function concatStringNodes(nodes: LibPgQueryAST.Node[] | undefined): string {
 }
 
 /**
- * `resolveColumnRefNonNull` lets a caller answer whether a bare column reference
- * is non-null using knowledge this function lacks on its own (e.g. a view body's
- * base-table NOT NULL constraints). When provided, it is consulted for ColumnRef
- * nodes so expression columns like `a || b` over NOT NULL columns are inferred
- * non-null. It is threaded through the recursion so it applies to nested operands.
+ * `resolveColumnRefNonNull` lets the caller decide whether a column ref is non-null from
+ * knowledge this function lacks (e.g. a view body's base-table NOT NULL constraints).
  */
-export function isColumnNonNullable(
-  val: LibPgQueryAST.Node | undefined,
-  root: LibPgQueryAST.ParseResult,
-  aggregateNames: Set<string> | undefined,
-  resolveColumnRefNonNull?: (columnRef: LibPgQueryAST.ColumnRef) => boolean,
-): boolean {
+export function isColumnNonNullable(params: {
+  val: LibPgQueryAST.Node | undefined;
+  root: LibPgQueryAST.ParseResult;
+  aggregateNames: Set<string> | undefined;
+  resolveColumnRefNonNull: ((columnRef: LibPgQueryAST.ColumnRef) => boolean) | undefined;
+}): boolean {
+  const { val, root, aggregateNames, resolveColumnRefNonNull } = params;
+
   if (val === undefined) {
     return false;
   }
@@ -112,7 +111,12 @@ export function isColumnNonNullable(
   }
 
   if (val.TypeCast?.arg) {
-    return isColumnNonNullable(val.TypeCast.arg, root, aggregateNames, resolveColumnRefNonNull);
+    return isColumnNonNullable({
+      val: val.TypeCast.arg,
+      root,
+      aggregateNames,
+      resolveColumnRefNonNull,
+    });
   }
 
   if (val.SubLink) {
@@ -139,12 +143,26 @@ export function isColumnNonNullable(
 
         const expression = innerSelect.targetList?.[0]?.ResTarget?.val;
 
-        return expression !== undefined && isColumnNonNullable(expression, root, aggregateNames);
+        // The subquery has its own scope, so the outer resolveColumnRefNonNull does not apply.
+        return (
+          expression !== undefined &&
+          isColumnNonNullable({
+            val: expression,
+            root,
+            aggregateNames,
+            resolveColumnRefNonNull: undefined,
+          })
+        );
       }
 
       case LibPgQueryAST.SubLinkType.MULTIEXPR_SUBLINK:
       case LibPgQueryAST.SubLinkType.CTE_SUBLINK:
-        return isColumnNonNullable(val.SubLink.subselect, root, aggregateNames);
+        return isColumnNonNullable({
+          val: val.SubLink.subselect,
+          root,
+          aggregateNames,
+          resolveColumnRefNonNull: undefined,
+        });
 
       case LibPgQueryAST.SubLinkType.SUB_LINK_TYPE_UNDEFINED:
       case LibPgQueryAST.SubLinkType.UNRECOGNIZED:
@@ -165,28 +183,41 @@ export function isColumnNonNullable(
 
   if (val.A_Expr?.kind === LibPgQueryAST.AExprKind.AEXPR_OP) {
     return (
-      isColumnNonNullable(val.A_Expr.lexpr, root, aggregateNames, resolveColumnRefNonNull) &&
-      isColumnNonNullable(val.A_Expr.rexpr, root, aggregateNames, resolveColumnRefNonNull)
+      isColumnNonNullable({
+        val: val.A_Expr.lexpr,
+        root,
+        aggregateNames,
+        resolveColumnRefNonNull,
+      }) &&
+      isColumnNonNullable({ val: val.A_Expr.rexpr, root, aggregateNames, resolveColumnRefNonNull })
     );
   }
 
   if (val.CaseExpr) {
+    // A CASE with no ELSE clause is implicitly `ELSE NULL`, so it can always return NULL.
+    if (val.CaseExpr.defresult === undefined) {
+      return false;
+    }
+
     for (const when of val.CaseExpr.args) {
       if (
-        !isColumnNonNullable(when.CaseWhen?.result, root, aggregateNames, resolveColumnRefNonNull)
+        !isColumnNonNullable({
+          val: when.CaseWhen?.result,
+          root,
+          aggregateNames,
+          resolveColumnRefNonNull,
+        })
       ) {
         return false;
       }
     }
 
-    if (
-      val.CaseExpr.defresult &&
-      !isColumnNonNullable(val.CaseExpr.defresult, root, aggregateNames, resolveColumnRefNonNull)
-    ) {
-      return false;
-    }
-
-    return true;
+    return isColumnNonNullable({
+      val: val.CaseExpr.defresult,
+      root,
+      aggregateNames,
+      resolveColumnRefNonNull,
+    });
   }
 
   if (val.ColumnRef) {
@@ -215,7 +246,7 @@ export function isColumnNonNullable(
 
   if (val.CoalesceExpr) {
     for (const arg of val.CoalesceExpr.args) {
-      if (isColumnNonNullable(arg, root, aggregateNames, resolveColumnRefNonNull)) {
+      if (isColumnNonNullable({ val: arg, root, aggregateNames, resolveColumnRefNonNull })) {
         return true;
       }
     }
@@ -525,7 +556,15 @@ function getNonNullableColumnsInSelectStmt(
       targetNames.add(getTargetName(target.ResTarget));
     }
 
-    if (target.ResTarget && isColumnNonNullable(target.ResTarget.val, root, aggregateNames)) {
+    if (
+      target.ResTarget &&
+      isColumnNonNullable({
+        val: target.ResTarget.val,
+        root,
+        aggregateNames,
+        resolveColumnRefNonNull: undefined,
+      })
+    ) {
       nonNullableColumns.add(getTargetName(target.ResTarget));
     }
   }


### PR DESCRIPTION
fixes https://github.com/ts-safeql/safeql/issues/192

## Summary
PostgreSQL reports view and materialized-view columns as nullable in catalog metadata, so SafeQL often generated overly broad null-including types for view outputs.

This change makes SafeQL inspect each view’s actual SQL definition and infer which output columns are truly non-nullable, while staying conservative when safety can’t be proven.

The result is cleaner generated types for typical view patterns (including aliases, passthrough columns, joins, nested views, and expression-based outputs) without risking unsound `NOT NULL` inference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved view column nullability inference for more accurate generated TypeScript types.
  * Added demo read models and a materialized view for episode counts in the playground.

* **Bug Fixes**
  * Episodes now require a season (NOT NULL) and are deleted automatically when their season is removed (cascade).

* **Tests**
  * New tests validating view-based non-nullability inference and related edge cases.

* **Documentation**
  * Changeset entry added documenting the minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->