### PR TITLE
fix: resolve JSON ->>/#>> as text, and treat any as compatible with annotations

### DIFF
--- a/.changeset/jsonb-arrow-text-and-any-comparison.md
+++ b/.changeset/jsonb-arrow-text-and-any-comparison.md
@@ -1,0 +1,9 @@
+---
+"@ts-safeql/generate": patch
+"@ts-safeql/eslint-plugin": patch
+---
+
+Fix two JSON-related typing edge cases in SafeQL:
+
+- In `@ts-safeql/generate`, infer `->>` and `#>>` as `text` even when the left side type is not fully known, preventing generated `unknown` types inside JSON object/array expressions.
+- In `@ts-safeql/eslint-plugin`, treat `any` as a wildcard during expected/generated comparison so JSON columns typed as `any` no longer produce false mismatches against concrete annotations.

--- a/packages/eslint-plugin/src/rules/check-sql.rule.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.rule.ts
@@ -45,6 +45,7 @@ import {
   getFinalResolvedTargetString,
   getResolvedTargetComparableString,
   getResolvedTargetString,
+  normalizeAnyForComparison,
   reportBaseError,
   reportDuplicateColumns,
   reportIncorrectTypeAnnotations,
@@ -651,15 +652,19 @@ function getResolvedTargetsEquality(params: {
     };
   }
 
+  // Normalized values are only used for the equality check below; the originals
+  // are returned unchanged for the error message.
+  const normalized = normalizeAnyForComparison(params.expected, params.generated);
+
   let expectedString = getResolvedTargetComparableString({
-    target: params.expected,
+    target: normalized.expected,
     nullAsOptional: false,
     nullAsUndefined: false,
     inferLiterals: params.inferLiterals,
   });
 
   let generatedString = getResolvedTargetComparableString({
-    target: params.generated,
+    target: normalized.generated,
     nullAsOptional: params.nullAsOptional,
     nullAsUndefined: params.nullAsUndefined,
     inferLiterals: params.inferLiterals,

--- a/packages/eslint-plugin/src/rules/check-sql.utils.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.utils.ts
@@ -396,6 +396,126 @@ function unique<T>(array: T[]): T[] {
   return Array.from(new Set(array));
 }
 
+/**
+ * `json`/`jsonb` columns are generated as `any`, and `any` is a TypeScript
+ * wildcard — assignable to and from every type — so any concrete annotation on
+ * such a column is valid. A textual comparison would reject it, so we normalize
+ * an `any` on either side to compatible before comparing.
+ *
+ * The expected and generated trees are the same shape but distinct types;
+ * `ComparableTarget` is the common shape both widen into, keeping the
+ * normalization a single cast-free recursion.
+ */
+type ComparableTarget =
+  | { kind: "type"; value: string }
+  | { kind: "literal"; value: string; base: ComparableTarget }
+  | { kind: "union"; value: ComparableTarget[] }
+  | { kind: "array"; value: ComparableTarget; syntax?: "array-type" | "type-reference" }
+  | { kind: "object"; value: [string, ComparableTarget][] };
+
+const ANY: ComparableTarget = { kind: "type", value: "any" };
+
+const isAny = (target: ComparableTarget): boolean =>
+  target.kind === "type" && target.value === "any";
+
+/** In TypeScript `any | T` is just `any`, so collapse any union containing `any`. */
+function collapseAny(target: ComparableTarget): ComparableTarget {
+  switch (target.kind) {
+    case "type":
+      return target;
+    case "literal":
+      return { kind: "literal", value: target.value, base: collapseAny(target.base) };
+    case "array":
+      return { kind: "array", value: collapseAny(target.value), syntax: target.syntax };
+    case "object":
+      return {
+        kind: "object",
+        value: target.value.map(([key, v]): [string, ComparableTarget] => [key, collapseAny(v)]),
+      };
+    case "union": {
+      const members = target.value.map(collapseAny);
+      return members.some(isAny) ? ANY : { kind: "union", value: members };
+    }
+  }
+}
+
+/**
+ * Where either side is `any`, set both positions to `any` so they serialize
+ * identically. Mismatched shapes are returned as-is for the regular textual
+ * comparison, so a genuine mismatch is never hidden.
+ */
+function alignAny(
+  expected: ComparableTarget,
+  generated: ComparableTarget,
+): [ComparableTarget, ComparableTarget] {
+  if (isAny(expected) || isAny(generated)) return [ANY, ANY];
+  if (expected.kind !== generated.kind) return [expected, generated];
+
+  if (expected.kind === "array" && generated.kind === "array") {
+    const [e, g] = alignAny(expected.value, generated.value);
+    return [
+      { kind: "array", value: e, syntax: expected.syntax },
+      { kind: "array", value: g, syntax: generated.syntax },
+    ];
+  }
+
+  if (expected.kind === "object" && generated.kind === "object") {
+    const generatedByKey = new Map(generated.value);
+    const aligned = new Map(generated.value);
+
+    const expectedEntries = expected.value.map(([key, value]): [string, ComparableTarget] => {
+      const counterpart = generatedByKey.get(key);
+      if (counterpart === undefined) return [key, value];
+
+      const [e, g] = alignAny(value, counterpart);
+      aligned.set(key, g);
+      return [key, e];
+    });
+
+    return [
+      { kind: "object", value: expectedEntries },
+      { kind: "object", value: [...aligned] },
+    ];
+  }
+
+  if (expected.kind === "union" && generated.kind === "union") {
+    // Members have no inherent order, so pair each expected member with the first
+    // unpaired generated member of the same kind. This reaches an `any` nested
+    // inside a member (e.g. `{ data: any }[] | null`); unpaired members stay as-is
+    // and the full union is still compared textually, so no real mismatch is masked.
+    const generatedMembers = [...generated.value];
+    const paired = new Set<number>();
+
+    const expectedMembers = expected.value.map((member) => {
+      const match = generatedMembers.findIndex((g, i) => !paired.has(i) && g.kind === member.kind);
+      if (match === -1) return member;
+
+      paired.add(match);
+      const [e, g] = alignAny(member, generatedMembers[match]);
+      generatedMembers[match] = g;
+      return e;
+    });
+
+    return [
+      { kind: "union", value: expectedMembers },
+      { kind: "union", value: generatedMembers },
+    ];
+  }
+
+  return [expected, generated];
+}
+
+export function normalizeAnyForComparison(
+  expected: ExpectedResolvedTarget,
+  generated: ResolvedTarget,
+): { expected: ComparableTarget; generated: ComparableTarget } {
+  const [alignedExpected, alignedGenerated] = alignAny(
+    collapseAny(expected),
+    collapseAny(generated),
+  );
+  return { expected: alignedExpected, generated: alignedGenerated };
+}
+
 export function getResolvedTargetComparableString(params: {
   target: ExpectedResolvedTarget | ResolvedTarget;
   nullAsOptional: boolean;

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.jsonb.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.jsonb.test.ts
@@ -90,6 +90,24 @@ ruleTester.run("json(b)", checkSqlRule, {
         `,
     },
     {
+      name: "json/b: jsonb column (any) should be compatible with a Record<string, T> annotation",
+      options: withConnection(connections.withTag),
+      code: `
+          type Metadata = { id: number };
+          const rows = await sql<{ jsonb_col: Record<string, Metadata> }>\`SELECT jsonb_col FROM test_jsonb\`;
+        `,
+    },
+    {
+      name: "json/b: any nested inside a union member should be compatible with a concrete annotation",
+      options: withConnection(connections.withTag),
+      code: `
+          type Metadata = { id: number };
+          const rows = await sql<{ agg: { data: Record<string, Metadata> }[] | null }>\`
+            SELECT jsonb_agg(jsonb_build_object('data', jsonb_col)) AS agg FROM test_jsonb
+          \`;
+        `,
+    },
+    {
       name: "json/b: fieldTransform camel should apply to jsonb_build_object keys",
       options: withConnection(connections.withTag, {
         targets: [{ tag: "sql", fieldTransform: "camel" }],

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -472,6 +472,15 @@ function getDescribedAExpr({
 
   const getType = (): ASTDescribedColumnType | undefined => {
     const nullable = getNullable();
+
+    // `->>` and `#>>` always return `text` in PostgreSQL. Resolve them directly
+    // rather than via the operand-keyed lookup below, which misses when the left
+    // operand's type is imprecise (e.g. `unknown` from `jsonb_array_elements`)
+    // and would otherwise collapse the expression to `unknown`.
+    if (operator === "->>" || operator === "#>>") {
+      return resolveType({ context, nullable, type: context.toTypeScriptType({ name: "text" }) });
+    }
+
     const [dleft, doperator, dright] = downcast();
 
     const type =

--- a/packages/generate/src/generate/generate.aggregates.test.ts
+++ b/packages/generate/src/generate/generate.aggregates.test.ts
@@ -428,6 +428,65 @@ test("select jsonb_agg(tbl) from (subselect) tbl", async () => {
   });
 });
 
+test("select jsonb_agg(jsonb_build_object(const, jsonb->>, const, ARRAY[jsonb->>])) from jsonb_array_elements subquery", async () => {
+  await testQuery({
+    query: `
+      SELECT
+        jsonb_agg(
+          jsonb_build_object(
+            'key', label->>'key',
+            'values', ARRAY[label->>'value']
+          )
+        ) AS entries
+      FROM (
+             SELECT jsonb_array_elements('[]'::jsonb) AS label
+           ) subquery
+    `,
+    expected: [
+      [
+        "entries",
+        {
+          kind: "union",
+          value: [
+            {
+              kind: "array",
+              value: {
+                kind: "object",
+                value: [
+                  [
+                    "key",
+                    {
+                      kind: "union",
+                      value: [
+                        { kind: "type", value: "string", type: "text" },
+                        { kind: "type", value: "null", type: "null" },
+                      ],
+                    },
+                  ],
+                  [
+                    "values",
+                    {
+                      kind: "array",
+                      value: {
+                        kind: "union",
+                        value: [
+                          { kind: "type", value: "string", type: "text" },
+                          { kind: "type", value: "null", type: "null" },
+                        ],
+                      },
+                    },
+                  ],
+                ],
+              },
+            },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
 test("select jsonb_agg(table with nullable column)", async () => {
   await testQuery({
     query: `select jsonb_agg(test_jsonb) FROM test_jsonb`,


### PR DESCRIPTION
## Summary

- In `@ts-safeql/generate`, resolve JSON extraction operators `->>` and `#>>` as `text` directly, so inference doesn’t fall back to `unknown` in common JSON-building expressions when the left-hand type can’t be resolved.
- In `@ts-safeql/eslint-plugin`, relax annotation comparison for `any` on either side to match TypeScript’s wildcard behavior, so generated `any` JSON columns (`json`/`jsonb`) can be annotated with concrete shapes without false positives.

## Scope

- `@ts-safeql/generate`
- `@ts-safeql/eslint-plugin`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL JSON operators (->>, #>>) now infer as text even when operand type is unknown.
  * Type comparisons treat any as a wildcard to avoid false mismatches between annotated and generated types (reduces spurious lint errors).

* **Tests**
  * Added test coverage for jsonb/json handling and any-wildcard compatibility in generated types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->