### PR TITLE
fix: skip the one-of IN-rewrite when the parameter has a trailing cast

### DIFF
--- a/.changeset/one-of-trailing-cast.md
+++ b/.changeset/one-of-trailing-cast.md
@@ -1,0 +1,7 @@
+---
+"@ts-safeql/eslint-plugin": patch
+---
+
+Skip the `one-of` `IN (...)` rewrite when the parameter carries a trailing cast.
+
+A string-literal-union or enum parameter compared with `=` (e.g. `WHERE role = ${cert}`) is rewritten to `role IN ('owner', 'admin')` so the column is validated against every value. When the parameter carries a trailing cast — `WHERE role = ${cert}::role`, which is required when the column is a real PostgreSQL enum/domain — the cast was applied to the boolean `IN` result, producing `cannot cast type boolean to role` and forcing a manual `String(...)` widening. The rewrite is now skipped when the parameter is immediately followed by a `::cast`, falling through to the `$n::cast` placeholder (the same path already used in non-equality contexts like `${cert}::role IS NULL`), which composes with the trailing cast correctly.

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.one-of.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.one-of.test.ts
@@ -24,6 +24,42 @@ ruleTester.run("one-of transformation", checkSqlRule, {
         `,
     },
     {
+      name: "select where with a trailing cast (must not apply the IN-rewrite over a ::cast)",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+          function union(cert: "owner" | "admin") {
+            return sql\`SELECT FROM member WHERE role = \${cert}::role\`
+          }
+        `,
+    },
+    {
+      name: "join on context with a trailing cast",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+          function union(cert: "owner" | "admin") {
+            return sql\`SELECT FROM member c JOIN role_metadata ct ON c.role = \${cert}::role\`
+          }
+        `,
+    },
+    {
+      name: "having context with a trailing cast",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+          function union(cert: "owner" | "admin") {
+            return sql\`SELECT FROM member GROUP BY role HAVING role = \${cert}::role\`
+          }
+        `,
+    },
+    {
+      name: "whitespace between the parameter and the trailing cast",
+      options: withConnection(connections.withTag),
+      code: normalizeIndent`
+          function union(cert: "owner" | "admin") {
+            return sql\`SELECT FROM member WHERE role = \${cert} ::role\`
+          }
+        `,
+    },
+    {
       name: "join context",
       options: withConnection(connections.withTag),
       code: normalizeIndent`

--- a/packages/eslint-plugin/src/utils/ts-pg.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts-pg.utils.ts
@@ -126,8 +126,13 @@ export function mapTemplateLiteralToQueryText(
 
     const escapePgValue = (text: string) => text.replace(/'/g, "''");
 
+    // `col = ${param}` becomes `col IN (...)`, so a trailing `::cast` would land on a boolean
+    // ("cannot cast type boolean to ..."); skip the rewrite and let the `$n::cast` path carry it.
+    const isFollowedByCast = /^\s*::/.test(quasi.quasis[quasiIdx + 1]?.value.raw ?? "");
+
     if (
       pgTypeValue.kind === "one-of" &&
+      !isFollowedByCast &&
       $queryText.trimEnd().endsWith("=") &&
       isLastQueryContextOneOf($queryText, ["SELECT", "ON", "WHERE", "WHEN", "HAVING", "RETURNING"])
     ) {


### PR DESCRIPTION
Follow-up to #475 (tuple / template-literal params). Those PRs taught `checkType` to resolve more parameter types to a Postgres type; this one fixes the remaining case where the resolution is already correct but the *emitted SQL* breaks: a `one-of` (string-literal-union / enum) parameter followed by a `::cast` in an equality comparison.

```ts
// cert: "owner" | "admin"; `role` is the Postgres enum type
function getMembers(cert: "owner" | "admin") {
  return sql`SELECT * FROM member WHERE role = ${cert}::role`;
}
```

A `one-of` parameter compared with `=` is rewritten to `IN (...)` so the column is validated against every value (`WHERE role = ${cert}` → `WHERE role IN ('owner', 'admin')`). But the rewrite turns the comparison into a boolean, so a trailing `::cast` — required whenever the column is a real enum/domain — lands on that boolean:

| | Behaviour |
|---|---|
| **Before** | ❌ `WHERE role IN ('owner', 'admin')::role` → `cannot cast type boolean to role` |
| **Before — workaround** | widen the param: `${String(cert)}::role` (drops out of the `one-of` path) |
| **After** | ✅ `WHERE role = $1::text::role` — the param is passed directly |

`UPDATE ... SET role = ${cert}::role` already worked, because `SET` isn't one of the rewrite's contexts (`SELECT` / `WHERE` / `ON` / `WHEN` / `HAVING` / `RETURNING`) — and none of those had a test covering a trailing cast.

## Fix

Skip the `=` → `IN (...)` rewrite when the parameter is immediately followed by a `::cast`, falling through to the existing `$n::cast` placeholder — the same path already used in non-equality contexts like `${cert}::role IS NULL`:

```ts
const isFollowedByCast = /^\s*::/.test(quasi.quasis[quasiIdx + 1]?.value.raw ?? "");
```

## Type safety preserved

The change only affects which SQL is emitted, never whether type errors surface:

- **Without a trailing cast** (`WHERE role = ${cert}`) the `IN (...)` rewrite is untouched, so the column is still validated against every union value.
- **With a trailing cast** the param flows through `$n::cast`, exactly as the existing `${cert}::role IS NULL` and `SET role = ${cert}::role` paths already do; a genuine incompatibility the cast can't bridge is still reported. Per-value validation in the cast branch is deferred to the explicit cast — the same as the `String(cert)` workaround it replaces.

## Tests

Adds four `valid` cases to `check-sql.one-of.test.ts`, one per rewrite context, each carrying a trailing cast:

| Context | SQL |
|---|---|
| select / where | `WHERE role = ${cert}::role` |
| join / on | `JOIN role_metadata ct ON c.role = ${cert}::role` |
| having | `GROUP BY role HAVING role = ${cert}::role` |
| whitespace before cast | `WHERE role = ${cert} ::role` |

The `where` case doubles as a one-to-one red-team for the bug: it fails on `main` with the verbatim `cannot cast type boolean to role` and passes with the fix. DB-backed `check-sql` suite (295 tests) green, no regression to the existing `one-of` cases.

Changeset (`patch`, `@ts-safeql/eslint-plugin`): `one-of-trailing-cast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
