### PR TITLE
fix: false type mismatch for column names containing ", "

### DIFF
--- a/.changeset/fix-comma-keys-false-mismatch.md
+++ b/.changeset/fix-comma-keys-false-mismatch.md
@@ -1,0 +1,7 @@
+---
+"@ts-safeql/eslint-plugin": patch
+---
+
+Fix a false "incorrect type annotation" error for columns whose names contain `", "`.
+
+The type-equality check normalized ordering by re-sorting comma-separated fragments of the serialized type, which split such column names apart. Combined with a `transform` (e.g. `"{type}[]"`), this could report two identical shapes as a mismatch. The serialized form is already canonical, so the redundant pass was removed.

--- a/packages/eslint-plugin/src/rules/check-sql.rule.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.rule.ts
@@ -681,9 +681,12 @@ function getResolvedTargetsEquality(params: {
   expectedString = expectedString.replace(/'/g, '"');
   generatedString = generatedString.replace(/'/g, '"');
 
-  expectedString = expectedString.split(", ").sort().join(", ");
-  generatedString = generatedString.split(", ").sort().join(", ");
-
+  // `getResolvedTargetComparableString` already emits a canonical form (object
+  // entries and union members are sorted internally), so no further reordering
+  // is needed here. A previous `split(", ").sort()` pass shattered column names
+  // containing ", " (e.g. a quoted alias like `"resolved, open %"`) and, together
+  // with a transform applied only to the generated side, moved the array suffix to
+  // a different position on each side — reporting a mismatch between identical shapes.
   if (params.transform !== undefined) {
     generatedString = transformTypes(generatedString, params.transform);
   }

--- a/packages/eslint-plugin/src/rules/check-sql.rule.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.rule.ts
@@ -681,12 +681,7 @@ function getResolvedTargetsEquality(params: {
   expectedString = expectedString.replace(/'/g, '"');
   generatedString = generatedString.replace(/'/g, '"');
 
-  // `getResolvedTargetComparableString` already emits a canonical form (object
-  // entries and union members are sorted internally), so no further reordering
-  // is needed here. A previous `split(", ").sort()` pass shattered column names
-  // containing ", " (e.g. a quoted alias like `"resolved, open %"`) and, together
-  // with a transform applied only to the generated side, moved the array suffix to
-  // a different position on each side — reporting a mismatch between identical shapes.
+  // The comparable form is already canonical, so no further reordering is needed.
   if (params.transform !== undefined) {
     generatedString = transformTypes(generatedString, params.transform);
   }

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.comma-keys.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.comma-keys.test.ts
@@ -2,13 +2,8 @@ import { checkSqlRule, ruleTester, setupCheckSqlRuleTester } from "./check-sql.t
 
 const { connections, withConnection } = setupCheckSqlRuleTester();
 
-// Regression: a materialized view exposing computed columns whose quoted aliases
-// contain ", " (e.g. `"admins, active %"`), queried through a wrapper with a
-// `transform: "{type}[]"`. The equality check used to `split(", ").sort()` the
-// serialized types, which shattered such keys; because the transform appends the
-// array suffix to the generated side only — after the split — the `[]` landed in
-// a different position on each side and an identical shape was reported as a
-// mismatch (with an Expected/Actual that rendered identically).
+// Regression: column names containing ", " must compare correctly, including
+// through a `transform: "{type}[]"`.
 const target = {
   wrapper: "conn.query",
   transform: "{type}[]" as const,

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.comma-keys.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.comma-keys.test.ts
@@ -1,0 +1,34 @@
+import { checkSqlRule, ruleTester, setupCheckSqlRuleTester } from "./check-sql.test-utils";
+
+const { connections, withConnection } = setupCheckSqlRuleTester();
+
+// Regression: a materialized view exposing computed columns whose quoted aliases
+// contain ", " (e.g. `"admins, active %"`), queried through a wrapper with a
+// `transform: "{type}[]"`. The equality check used to `split(", ").sort()` the
+// serialized types, which shattered such keys; because the transform appends the
+// array suffix to the generated side only — after the split — the `[]` landed in
+// a different position on each side and an identical shape was reported as a
+// mismatch (with an Expected/Actual that rendered identically).
+const target = {
+  wrapper: "conn.query",
+  transform: "{type}[]" as const,
+};
+
+ruleTester.run("comma-containing column names", checkSqlRule, {
+  valid: [
+    {
+      name: "matview columns whose names contain ', ' compare as equal",
+      options: withConnection(connections.base, { targets: [target] }),
+      code: `const result = conn.query<{ member_id: number; "admins, active %": number; "viewers, inactive %": number }[]>(sql\`SELECT * FROM member_role_ratio\`);`,
+    },
+  ],
+  invalid: [
+    {
+      name: "a genuine type mismatch on a comma-named column is still reported",
+      options: withConnection(connections.base, { targets: [target] }),
+      code: `const result = conn.query<{ member_id: number; "admins, active %": string; "viewers, inactive %": number }[]>(sql\`SELECT * FROM member_role_ratio\`);`,
+      output: `const result = conn.query<{ member_id: number; 'admins, active %': number; 'viewers, inactive %': number }[]>(sql\`SELECT * FROM member_role_ratio\`);`,
+      errors: [{ messageId: "incorrectTypeAnnotations" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.migrations.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.migrations.ts
@@ -126,5 +126,26 @@ export function runCheckSqlMigrations<TTypes extends Record<string, unknown>>(sq
     CREATE TABLE test_nullable_timestamptz (
       colname TIMESTAMPTZ
     );
+
+    -- Mirrors a real-world materialized view: computed FLOAT columns whose
+    -- quoted aliases contain ", ", grouped per key. Used to verify that such
+    -- column names compare correctly against their annotation.
+    CREATE MATERIALIZED VIEW member_role_ratio AS
+      SELECT
+        member.id AS member_id,
+        (
+          COUNT(*) FILTER (WHERE role = 'admin')::FLOAT /
+          (
+            CASE COUNT(*)::FLOAT WHEN 0 THEN 1 ELSE COUNT(*)::FLOAT END
+          )
+        ) * 100 AS "admins, active %",
+        (
+          COUNT(*) FILTER (WHERE role = 'viewer')::FLOAT /
+          (
+            CASE COUNT(*)::FLOAT WHEN 0 THEN 1 ELSE COUNT(*)::FLOAT END
+          )
+        ) * 100 AS "viewers, inactive %"
+      FROM member
+      GROUP BY member.id;
 `);
 }

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.migrations.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.migrations.ts
@@ -127,9 +127,7 @@ export function runCheckSqlMigrations<TTypes extends Record<string, unknown>>(sq
       colname TIMESTAMPTZ
     );
 
-    -- Mirrors a real-world materialized view: computed FLOAT columns whose
-    -- quoted aliases contain ", ", grouped per key. Used to verify that such
-    -- column names compare correctly against their annotation.
+    -- Computed columns whose quoted aliases contain ", ".
     CREATE MATERIALIZED VIEW member_role_ratio AS
       SELECT
         member.id AS member_id,


### PR DESCRIPTION
## Problem

A query whose result columns have names containing `", "` (e.g. quoted aggregate aliases) could be reported with an **incorrect type annotation** error even when the annotation was correct — and the reported `Expected` and `Actual` rendered identically, making it impossible to debug.

## Cause

The type-equality check normalized ordering by running `split(", ").sort()` over the serialized types. For a column name containing `", "`, this split the name into fragments and re-sorted them. Combined with a `transform` such as `"{type}[]"` (applied to the generated side only, after the split), the array suffix ended up in a different position on each side — so two identical shapes compared unequal.

This is a long-standing latent issue that only began to surface once view/materialized-view columns started being inferred as `NOT NULL` (5.3.0), which let these shapes match in the first place.

## Fix

The serialized form is already canonical (object entries and union members are sorted as they're built), so the redundant `split(", ").sort()` pass is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false "incorrect type annotation" errors for SQL column names containing commas (e.g., `", "`).
  * Improved type comparison logic to correctly handle column-name fragments and prevent incorrect mismatched type reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->