### PR TITLE
feat(plugin-utils): shared AST toolkit + plugin API foundation

### DIFF
--- a/packages/plugin-utils/src/ast-estree.ts
+++ b/packages/plugin-utils/src/ast-estree.ts
@@ -1,0 +1,55 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+
+export function getRootIdentifier(params: {
+  node: TSESTree.Expression;
+}): TSESTree.Identifier | undefined {
+  const node = unwrap(params.node);
+  if (node.type === "Identifier") return node;
+  if (node.type === "MemberExpression") return getRootIdentifier({ node: node.object });
+  if (node.type === "CallExpression") return getRootIdentifier({ node: node.callee });
+  return undefined;
+}
+
+export function getMethodName(params: { node: TSESTree.Expression }): string | undefined {
+  const node = unwrap(params.node);
+  if (node.type === "MemberExpression") return identifierName(node.property);
+  if (node.type === "CallExpression" && node.callee.type === "MemberExpression") {
+    return identifierName(node.callee.property);
+  }
+  return undefined;
+}
+
+function unwrap(node: TSESTree.Expression): TSESTree.Expression {
+  switch (node.type) {
+    case "ChainExpression":
+    case "TSNonNullExpression":
+    case "TSAsExpression":
+    case "TSSatisfiesExpression":
+    case "TSTypeAssertion":
+    case "TSInstantiationExpression":
+      return unwrap(node.expression);
+    case "AwaitExpression":
+      return unwrap(node.argument);
+    default:
+      return node;
+  }
+}
+
+export function getStringLiterals(params: {
+  nodes: readonly (TSESTree.Expression | TSESTree.SpreadElement | null)[];
+}): string[] | undefined {
+  const parts: string[] = [];
+
+  for (const node of params.nodes) {
+    if (node?.type !== "Literal" || typeof node.value !== "string") return undefined;
+    parts.push(node.value);
+  }
+
+  return parts;
+}
+
+function identifierName(
+  node: TSESTree.Expression | TSESTree.PrivateIdentifier,
+): string | undefined {
+  return node.type === "Identifier" ? node.name : undefined;
+}

--- a/packages/plugin-utils/src/ast.ts
+++ b/packages/plugin-utils/src/ast.ts
@@ -1,0 +1,299 @@
+import path from "path";
+import ts from "typescript";
+
+export * as estree from "./ast-estree";
+
+export type StaticValue = string | number | boolean | bigint | null | StaticValue[];
+
+export const UNRESOLVED = Symbol("unresolved");
+
+export function unwrap(params: { node: ts.Node }): ts.Node {
+  const { node } = params;
+  if (
+    ts.isAsExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isAwaitExpression(node)
+  ) {
+    return unwrap({ node: node.expression });
+  }
+
+  return node;
+}
+
+export function getRootIdentifier(params: { node: ts.Node }): ts.Identifier | undefined {
+  const node = unwrap(params);
+  if (ts.isIdentifier(node)) return node;
+  if (ts.isPropertyAccessExpression(node)) return getRootIdentifier({ node: node.expression });
+  if (ts.isCallExpression(node)) return getRootIdentifier({ node: node.expression });
+  return undefined;
+}
+
+export function isImportedFrom(params: {
+  node: ts.Node;
+  checker: ts.TypeChecker;
+  moduleName: string;
+}): boolean {
+  const { node, checker, moduleName } = params;
+  const root = getRootIdentifier({ node });
+  if (!root) return false;
+  return isSymbolImportedFrom({ checker, symbol: checker.getSymbolAtLocation(root), moduleName });
+}
+
+// Falls back to a `node_modules/<moduleName>` path so re-exports (which detach the import chain) still resolve.
+export function isSymbolImportedFrom(params: {
+  checker: ts.TypeChecker;
+  symbol: ts.Symbol | undefined;
+  moduleName: string;
+}): boolean {
+  const { checker, symbol, moduleName } = params;
+  if (!symbol) return false;
+
+  const candidates = getSymbolCandidates({ checker, symbol });
+
+  if (candidates.some((candidate) => isImportedFromModule(candidate, moduleName))) {
+    return true;
+  }
+
+  return candidates.some((candidate) =>
+    (candidate.declarations ?? []).some((declaration) =>
+      isPackageFile(declaration.getSourceFile().fileName, moduleName),
+    ),
+  );
+}
+
+export function getStaticValue(params: {
+  node: ts.Node | undefined;
+  checker: ts.TypeChecker;
+}): StaticValue | typeof UNRESOLVED {
+  return evaluateStaticValue(params.node, params.checker, new Set());
+}
+
+// `visited` guards against cyclic initializers (`const a = b; const b = a`); it
+// grows only per resolution path, so sibling values still resolve independently.
+function evaluateStaticValue(
+  node: ts.Node | undefined,
+  checker: ts.TypeChecker,
+  visited: Set<ts.Symbol>,
+): StaticValue | typeof UNRESOLVED {
+  if (!node) return UNRESOLVED;
+
+  const expression = unwrap({ node });
+
+  if (ts.isStringLiteralLike(expression)) return expression.text;
+  if (ts.isNumericLiteral(expression)) return Number(expression.text);
+  if (ts.isBigIntLiteral(expression)) return BigInt(expression.text.replace(/n$/, ""));
+  if (expression.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expression.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (expression.kind === ts.SyntaxKind.NullKeyword) return null;
+
+  if (ts.isPrefixUnaryExpression(expression) && expression.operator === ts.SyntaxKind.MinusToken) {
+    const operand = evaluateStaticValue(expression.operand, checker, visited);
+    if (typeof operand === "number") return -operand;
+    if (typeof operand === "bigint") return -operand;
+    return UNRESOLVED;
+  }
+
+  if (ts.isIdentifier(expression)) {
+    const symbol = resolveAliasedSymbol({
+      checker,
+      symbol: checker.getSymbolAtLocation(expression),
+    });
+    if (symbol && visited.has(symbol)) return UNRESOLVED;
+
+    const initializer = findInitializer({ identifier: expression, checker });
+    if (!initializer) return UNRESOLVED;
+
+    return evaluateStaticValue(
+      initializer,
+      checker,
+      symbol ? new Set(visited).add(symbol) : visited,
+    );
+  }
+
+  if (ts.isArrayLiteralExpression(expression)) {
+    const values: StaticValue[] = [];
+    for (const element of expression.elements) {
+      if (ts.isSpreadElement(element)) return UNRESOLVED;
+      const value = evaluateStaticValue(element, checker, visited);
+      if (value === UNRESOLVED) return UNRESOLVED;
+      values.push(value);
+    }
+    return values;
+  }
+
+  return UNRESOLVED;
+}
+
+// For a destructured binding, resolves the value actually bound, not the binding's default.
+export function findInitializer(params: {
+  identifier: ts.Identifier;
+  checker: ts.TypeChecker;
+}): ts.Expression | undefined {
+  const { identifier, checker } = params;
+  const resolved = resolveAliasedSymbol({
+    checker,
+    symbol: checker.getSymbolAtLocation(identifier),
+  });
+
+  for (const declaration of resolved?.declarations ?? []) {
+    if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+      return declaration.initializer;
+    }
+
+    if (ts.isBindingElement(declaration)) {
+      const bound = getBindingInitializer({ element: declaration });
+      if (bound) return bound;
+      if (declaration.initializer) return declaration.initializer;
+    }
+  }
+
+  return undefined;
+}
+
+export function getBindingInitializer(params: {
+  element: ts.BindingElement;
+}): ts.Expression | undefined {
+  const { element } = params;
+  if (element.dotDotDotToken) return undefined;
+
+  const source = getBindingSource(element.parent);
+  if (!source) return undefined;
+
+  if (ts.isObjectBindingPattern(element.parent)) {
+    return resolveObjectBindingElementInitializer(element, source);
+  }
+
+  if (ts.isArrayBindingPattern(element.parent)) {
+    return resolveArrayBindingElementInitializer(element, source);
+  }
+
+  return undefined;
+}
+
+export function getMethodName(params: { node: ts.Node }): string | undefined {
+  const current = unwrap(params);
+
+  if (ts.isPropertyAccessExpression(current)) return current.name.text;
+  if (ts.isCallExpression(current) && ts.isPropertyAccessExpression(current.expression)) {
+    return current.expression.name.text;
+  }
+
+  return undefined;
+}
+
+export function getStringLiterals(params: { nodes: readonly ts.Node[] }): string[] | undefined {
+  const parts: string[] = [];
+
+  for (const node of params.nodes) {
+    if (!ts.isStringLiteralLike(node)) return undefined;
+    parts.push(node.text);
+  }
+
+  return parts;
+}
+
+function getBindingSource(pattern: ts.BindingPattern): ts.Expression | undefined {
+  const owner = pattern.parent;
+
+  if (ts.isVariableDeclaration(owner)) return owner.initializer;
+  if (ts.isBindingElement(owner)) return getBindingInitializer({ element: owner });
+
+  return undefined;
+}
+
+function resolveObjectBindingElementInitializer(
+  element: ts.BindingElement,
+  source: ts.Expression,
+): ts.Expression | undefined {
+  if (!ts.isObjectLiteralExpression(source)) return undefined;
+
+  const propertyName = getPropertyName({ node: element.propertyName ?? element.name });
+  if (!propertyName) return undefined;
+
+  const property = source.properties.find(
+    (candidate): candidate is ts.PropertyAssignment | ts.ShorthandPropertyAssignment =>
+      (ts.isPropertyAssignment(candidate) || ts.isShorthandPropertyAssignment(candidate)) &&
+      getPropertyName({ node: candidate.name }) === propertyName,
+  );
+
+  if (!property) return undefined;
+  return ts.isPropertyAssignment(property) ? property.initializer : property.name;
+}
+
+function resolveArrayBindingElementInitializer(
+  element: ts.BindingElement,
+  source: ts.Expression,
+): ts.Expression | undefined {
+  if (!ts.isArrayLiteralExpression(source)) return undefined;
+
+  const index = element.parent.elements.indexOf(element);
+  if (index < 0) return undefined;
+
+  const value = source.elements[index];
+  return value && !ts.isOmittedExpression(value) && !ts.isSpreadElement(value) ? value : undefined;
+}
+
+export function getPropertyName(params: {
+  node: ts.PropertyName | ts.BindingName;
+}): string | undefined {
+  const { node } = params;
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return node.text;
+  if (ts.isStringLiteralLike(node) || ts.isNumericLiteral(node)) return node.text;
+  return undefined;
+}
+
+export function getMemberNames(params: { node: ts.Node }): string[] {
+  const expression = unwrap(params);
+
+  if (ts.isIdentifier(expression)) return [expression.text];
+  if (ts.isPropertyAccessExpression(expression)) {
+    return [...getMemberNames({ node: expression.expression }), expression.name.text];
+  }
+
+  return [];
+}
+
+export function resolveAliasedSymbol(params: {
+  checker: ts.TypeChecker;
+  symbol: ts.Symbol | undefined;
+}): ts.Symbol | undefined {
+  const { checker, symbol } = params;
+  if (!symbol) return undefined;
+  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+}
+
+export function getSymbolCandidates(params: {
+  checker: ts.TypeChecker;
+  symbol: ts.Symbol;
+}): ts.Symbol[] {
+  const { symbol } = params;
+  const resolved = resolveAliasedSymbol(params);
+  return resolved === undefined || resolved === symbol ? [symbol] : [symbol, resolved];
+}
+
+function isImportedFromModule(symbol: ts.Symbol, moduleName: string): boolean {
+  return (symbol.declarations ?? []).some((declaration) => {
+    let current: ts.Node | undefined = declaration;
+    while (current && !ts.isImportDeclaration(current)) current = current.parent;
+
+    return (
+      current?.moduleSpecifier !== undefined &&
+      ts.isStringLiteralLike(current.moduleSpecifier) &&
+      current.moduleSpecifier.text === moduleName
+    );
+  });
+}
+
+function isPackageFile(fileName: string, moduleName: string): boolean {
+  const parts = path.normalize(fileName).split(path.sep);
+  const segments = moduleName.split("/");
+  for (let i = 0; i <= parts.length - segments.length - 1; i++) {
+    if (parts[i] === "node_modules" && segments.every((seg, j) => parts[i + 1 + j] === seg)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/plugin-utils/src/index.contract.test.ts
+++ b/packages/plugin-utils/src/index.contract.test.ts
@@ -1,0 +1,60 @@
+import type ts from "typescript";
+import type { ParserServices } from "@typescript-eslint/utils";
+
+import type {
+  QuerySourceMapEntry,
+  ResolvedQuery,
+  SafeQLPlugin,
+  ResolveQueryContext,
+  QueryNodeSelector,
+} from "./index";
+
+const _sourcemap: QuerySourceMapEntry = {
+  original: {
+    start: 0,
+    end: 4,
+    text: "SELECT",
+  },
+  generated: {
+    start: 0,
+    end: 4,
+    text: "SELECT",
+  },
+  offset: 0,
+};
+
+const sampleResolvedQuery: ResolvedQuery = {
+  kind: "sql",
+  text: "SELECT id FROM users",
+  sourcemaps: [_sourcemap],
+};
+
+const _assertResolvedQueryType: ResolvedQuery = sampleResolvedQuery;
+
+const _queryKinds: QueryNodeSelector[] = [
+  { kind: "TaggedTemplateExpression" },
+  { kind: "CallExpression" },
+  { kind: "CallExpression", callee: { property: { nameIn: ["execute"] } } },
+];
+
+const _queryContext: ResolveQueryContext = {
+  checker: {} as ts.TypeChecker,
+  parser: {} as ParserServices,
+  precedingSQL: "SELECT * FROM users",
+  tsNode: {} as ts.Node,
+  tsType: {} as ts.Type,
+  tsTypeText: "{ id: number }",
+};
+
+const _testPlugin: SafeQLPlugin = {
+  name: "test-plugin",
+  queryNodeKinds: _queryKinds,
+  resolveQuery(context: ResolveQueryContext): ResolvedQuery | "skip" {
+    void context;
+    return sampleResolvedQuery;
+  },
+};
+
+void _assertResolvedQueryType;
+void _queryContext;
+void _testPlugin;

--- a/packages/plugin-utils/src/index.ts
+++ b/packages/plugin-utils/src/index.ts
@@ -2,6 +2,20 @@ import type { ParserServices, TSESLint, TSESTree } from "@typescript-eslint/util
 import type ts from "typescript";
 import type { Sql } from "postgres";
 
+export type QuerySourceMapEntry = {
+  original: {
+    start: number;
+    end: number;
+    text: string;
+  };
+  generated: {
+    start: number;
+    end: number;
+    text: string;
+  };
+  offset: number;
+};
+
 export interface ExpressionContext {
   precedingSQL: string;
   checker: ts.TypeChecker;
@@ -15,41 +29,91 @@ export interface TargetContext {
   parser: ParserServices;
 }
 
-/**
- * The object returned by a plugin's `setup` function (plus `name`).
- * Each property is an optional hook into SafeQL's analysis pipeline.
- */
+export interface ResolveQueryContext {
+  checker: ts.TypeChecker;
+  parser: ParserServices;
+  precedingSQL: string;
+  tsNode: ts.Node;
+  // Supplied lazily by the core; a resolver that gates syntactically and never reads them
+  // pays no checker cost.
+  readonly tsType: ts.Type;
+  readonly tsTypeText: string;
+}
+
+// Declarative selector for a non-tag query node. The core matches these syntactically and
+// never interprets what the names mean, so no library vocabulary leaks into the engine.
+// `callee.property.nameIn` admits a non-computed member call whose method name is listed;
+// omit it to admit every CallExpression (the plugin must then disown via `resolveQuery` "skip").
+export type QueryNodeSelector =
+  | { kind: "CallExpression"; callee?: { property?: { nameIn: string[] } } }
+  | { kind: "TaggedTemplateExpression" };
+
+export function matchesQueryNodeSelector(
+  node: TSESTree.Node,
+  selector: QueryNodeSelector,
+): boolean {
+  if (selector.kind === "TaggedTemplateExpression") {
+    return node.type === "TaggedTemplateExpression";
+  }
+
+  if (node.type !== "CallExpression") {
+    return false;
+  }
+
+  const nameIn = selector.callee?.property?.nameIn;
+  if (nameIn === undefined) {
+    return true;
+  }
+
+  return (
+    node.callee.type === "MemberExpression" &&
+    !node.callee.computed &&
+    node.callee.property.type === "Identifier" &&
+    nameIn.includes(node.callee.property.name)
+  );
+}
+
+export type ResolvedQuery = {
+  kind: "sql";
+  text: string;
+  sourcemaps: QuerySourceMapEntry[];
+};
+
+// The freshly-created, empty shadow database to apply the project's migrations to.
+export interface MigrateContext {
+  databaseUrl: string;
+  sql: Sql;
+  migrationsDir: string;
+  projectDir: string;
+}
+
+// The object a plugin's `setup` returns (plus `name`); each property is an optional pipeline hook.
 export interface SafeQLPlugin {
   name: string;
 
-  /** Deep-merged into the connection config. User-provided values always win. */
+  // Deep-merged into the connection config; user-provided values win.
   connectionDefaults?: Record<string, unknown>;
 
   createConnection?: {
-    /** Stable identifier for connection deduplication. Same key reuses the existing connection. */
+    // Same key reuses an existing connection.
     cacheKey: string;
     handler(): Promise<Sql>;
   };
 
-  /**
-   * Called for every `TaggedTemplateExpression` in the file.
-   *
-   * @returns `TargetMatch` to check this tag as SQL,
-   *          `false` to skip it,
-   *          `undefined` to defer to the next plugin or SafeQL's default matching.
-   */
+  // Apply project migrations to the shadow DB, replacing the built-in `.sql` runner. Throw to surface failures.
+  migrate?(context: MigrateContext): Promise<void>;
+
+  // Returns a TargetMatch to check the tag, `false` to skip, `undefined` to defer.
   onTarget?(params: {
     node: TSESTree.TaggedTemplateExpression;
     context: TargetContext;
   }): TargetMatch | false | undefined;
 
-  /**
-   * Called for each interpolated expression inside a matched template.
-   *
-   * @returns A SQL fragment (use `$N` as the positional placeholder),
-   *          `false` to skip the entire query,
-   *          `undefined` to use SafeQL's default `$N::type` behaviour.
-   */
+  // Non-tag query entrypoint (e.g. builder chains). Rule-only hook (runs in the checker process).
+  queryNodeKinds?: QueryNodeSelector[];
+  resolveQuery?(params: ResolveQueryContext): ResolvedQuery | "skip";
+
+  // Per interpolated expression: a SQL fragment (`$N` placeholder), `false` to skip, `undefined` for default `$N::type`.
   onExpression?(params: {
     node: TSESTree.Expression;
     context: ExpressionContext;
@@ -63,14 +127,7 @@ export type PluginResolvedTarget =
   | { kind: "array"; value: PluginResolvedTarget }
   | { kind: "object"; value: [string, PluginResolvedTarget][] };
 
-/**
- * Checks whether `actual` (DB-resolved type) is assignable to `expected`
- * (user-declared type, e.g. from a Zod schema) using TypeScript semantics.
- *
- * @param actual   - What the query actually returns.
- * @param expected - What the plugin or user declared.
- * @returns `true` when `actual` is assignable to `expected`.
- */
+// Whether `actual` (DB-resolved) is assignable to `expected` (user-declared) under TypeScript semantics.
 export function isAssignableTo(
   actual: PluginResolvedTarget,
   expected: PluginResolvedTarget,
@@ -128,46 +185,36 @@ function isLiteralOfType(literalValue: string, typeName: string): boolean {
   return false;
 }
 
-/** Passed to a plugin's {@link TargetMatch.typeCheck} after the query is resolved against the database. */
 export interface TypeCheckContext {
   node: TSESTree.TaggedTemplateExpression;
-  /** What the query actually returns (DB-resolved columns). */
   output: PluginResolvedTarget;
   checker: ts.TypeChecker;
   parser: ParserServices;
   sourceCode: Readonly<TSESLint.SourceCode>;
-  /** Normalises a target into a stable string, respecting `nullAsOptional` / `nullAsUndefined`. */
   getComparableString(target: PluginResolvedTarget): string;
 }
 
-/**
- * Returned by {@link TargetMatch.typeCheck} when the types do not match.
- * Return `undefined` from `typeCheck` when the types are correct.
- */
+// Return from `typeCheck` only on mismatch (`undefined` when types are correct).
 export interface TypeCheckReport {
   message: string;
-  /** Defaults to the tag expression when omitted. */
   node?: TSESTree.Node;
-  /** When provided, ESLint will offer an auto-fix replacing `node` with `text`. */
   fix?: { node: TSESTree.Node; text: string };
 }
 
 export interface TargetMatch {
   skipTypeAnnotations?: boolean;
-  /** When set, SafeQL delegates type comparison to the plugin instead of the built-in check. */
+  // When set, SafeQL delegates type comparison to the plugin.
   typeCheck?: (ctx: TypeCheckContext) => TypeCheckReport | undefined;
 }
 
-/** Serialisable descriptor produced by the config helper and consumed by the worker. */
 export interface PluginDescriptor {
   package: string;
   config?: Record<string, unknown>;
 }
 
 export interface DefinePluginOptions<TConfig> {
-  /** Prefixed with `safeql-plugin-` automatically. */
+  // Prefixed with `safeql-plugin-` automatically.
   name: string;
-  /** npm package name. Used to resolve the plugin in the worker. */
   package: string;
   setup: (config: TConfig) => Omit<SafeQLPlugin, "name">;
 }
@@ -178,31 +225,7 @@ export type SafeQLPluginExport<TConfig> = ({} extends TConfig
   factory: (config: TConfig) => SafeQLPlugin;
 };
 
-/**
- * Define a SafeQL plugin. The returned function is both the user-facing config
- * helper and (via `.factory`) the worker-side plugin constructor.
- *
- * @example
- * ```ts
- * // my-plugin/src/index.ts
- * export default definePlugin<MyConfig>({
- *   name: "my-db",
- *   package: "safeql-plugin-my-db",
- *   setup(config) {
- *     return {
- *       createConnection: {
- *         cacheKey: `my-db://${config.host}`,
- *         async handler() { return postgres(config.host); },
- *       },
- *     };
- *   },
- * });
- *
- * // eslint.config.js
- * import myDb from "safeql-plugin-my-db";
- * plugins: [myDb({ host: "localhost" })]
- * ```
- */
+// The returned function is both the user-facing config helper and (via `.factory`) the worker-side constructor.
 export function definePlugin<TConfig extends Record<string, unknown> = {}>(
   options: DefinePluginOptions<TConfig>,
 ): SafeQLPluginExport<TConfig> {
@@ -222,3 +245,5 @@ export function definePlugin<TConfig extends Record<string, unknown> = {}>(
 }
 
 export { PluginManager } from "./resolve";
+
+export * as ast from "./ast";

--- a/packages/plugin-utils/src/resolve.ts
+++ b/packages/plugin-utils/src/resolve.ts
@@ -1,12 +1,17 @@
 import { createRequire } from "module";
 import path from "path";
-import type { PluginDescriptor, SafeQLPlugin } from "./index";
+import type { MigrateContext, PluginDescriptor, SafeQLPlugin } from "./index";
 import type { Sql } from "postgres";
 
 export type ResolvedConnection = {
   pluginName: string;
   cacheKey: string;
   handler: () => Promise<Sql>;
+};
+
+export type ResolvedMigrate = {
+  pluginName: string;
+  handler: (context: MigrateContext) => Promise<void>;
 };
 
 export class PluginManager {
@@ -30,6 +35,10 @@ export class PluginManager {
     return this.pickConnection(plugins);
   }
 
+  resolveMigrate(descriptors: PluginDescriptor[], projectDir: string): ResolvedMigrate | undefined {
+    return this.pickMigrate(this.resolvePluginsSync(descriptors, projectDir));
+  }
+
   resolvePluginsSync(descriptors: PluginDescriptor[], projectDir: string): SafeQLPlugin[] {
     return descriptors.map((d) => this.resolveOneSync(d, projectDir));
   }
@@ -50,6 +59,19 @@ export class PluginManager {
           cacheKey: plugin.createConnection.cacheKey,
           handler: plugin.createConnection.handler,
         };
+      }
+    }
+
+    return result;
+  }
+
+  // Last plugin with a `migrate` hook wins, mirroring `pickConnection`.
+  private pickMigrate(plugins: SafeQLPlugin[]): ResolvedMigrate | undefined {
+    let result: ResolvedMigrate | undefined;
+
+    for (const plugin of plugins) {
+      if (plugin.migrate) {
+        result = { pluginName: plugin.name, handler: plugin.migrate.bind(plugin) };
       }
     }
 

--- a/packages/plugins/postgres-js/src/plugin.ts
+++ b/packages/plugins/postgres-js/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { TSESTree } from "@typescript-eslint/utils";
-import { definePlugin, type TargetContext, type TargetMatch } from "@ts-safeql/plugin-utils";
+import { ast, definePlugin, type TargetContext, type TargetMatch } from "@ts-safeql/plugin-utils";
 import ts from "typescript";
 
 export default definePlugin({
@@ -66,7 +66,7 @@ function buildTypeScriptExpressionSQL(
   checker: ts.TypeChecker,
   precedingSQL: string,
 ): string | false | undefined {
-  const expression = unwrapTypeScriptExpression(node);
+  const expression = ast.unwrap({ node: node });
 
   if (
     ts.isTaggedTemplateExpression(expression) &&
@@ -76,7 +76,7 @@ function buildTypeScriptExpressionSQL(
   }
 
   if (ts.isIdentifier(expression)) {
-    const initializer = findTypeScriptInitializer(expression, checker);
+    const initializer = ast.findInitializer({ identifier: expression, checker: checker });
 
     if (!initializer) {
       return undefined;
@@ -229,7 +229,7 @@ function getTypeScriptStaticValue(
     return unresolvedValue;
   }
 
-  const expression = unwrapTypeScriptExpression(node);
+  const expression = ast.unwrap({ node: node });
 
   if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
     return expression.text;
@@ -260,7 +260,7 @@ function getTypeScriptStaticValue(
       return undefined;
     }
 
-    const initializer = findTypeScriptInitializer(expression, checker);
+    const initializer = ast.findInitializer({ identifier: expression, checker: checker });
 
     if (!initializer) {
       return unresolvedValue;
@@ -317,7 +317,7 @@ function getTypeScriptStaticValue(
       return unresolvedValue;
     }
 
-    const key = getTypeScriptPropertyName(property.name);
+    const key = ast.getPropertyName({ node: property.name });
 
     if (!key) {
       return unresolvedValue;
@@ -335,35 +335,12 @@ function getTypeScriptStaticValue(
   return entries;
 }
 
-function getTypeScriptPropertyName(node: ts.PropertyName): string | undefined {
-  if (ts.isIdentifier(node) || ts.isStringLiteral(node) || ts.isNumericLiteral(node)) {
-    return node.text;
-  }
-
-  return undefined;
-}
-
-function unwrapTypeScriptExpression(node: ts.Node): ts.Node {
-  if (
-    ts.isAsExpression(node) ||
-    ts.isParenthesizedExpression(node) ||
-    ts.isNonNullExpression(node) ||
-    ts.isSatisfiesExpression(node) ||
-    ts.isTypeAssertionExpression(node) ||
-    ts.isAwaitExpression(node)
-  ) {
-    return unwrapTypeScriptExpression(node.expression);
-  }
-
-  return node;
-}
-
 function isTypeScriptNestedFragment(node: ts.TaggedTemplateExpression): boolean {
   return ts.isTemplateSpan(node.parent);
 }
 
 function isTypeScriptPostgresTag(node: ts.Node, checker: ts.TypeChecker): boolean {
-  const rootIdentifier = getTypeScriptRootIdentifier(node);
+  const rootIdentifier = ast.getRootIdentifier({ node });
 
   if (!rootIdentifier) {
     return false;
@@ -373,7 +350,7 @@ function isTypeScriptPostgresTag(node: ts.Node, checker: ts.TypeChecker): boolea
 }
 
 function isTypeScriptPostgresHelperCall(node: ts.CallExpression, checker: ts.TypeChecker): boolean {
-  const rootIdentifier = getTypeScriptRootIdentifier(node.expression);
+  const rootIdentifier = ast.getRootIdentifier({ node: node.expression });
 
   if (!rootIdentifier) {
     return false;
@@ -383,51 +360,19 @@ function isTypeScriptPostgresHelperCall(node: ts.CallExpression, checker: ts.Typ
 }
 
 function isTypeScriptTypedHelperCall(node: ts.CallExpression): boolean {
-  return getTypeScriptMemberNames(node.expression).includes("typed");
+  return ast.getMemberNames({ node: node.expression }).includes("typed");
 }
 
 function isTypeScriptUnsafeHelperCall(node: ts.CallExpression): boolean {
-  const memberNames = getTypeScriptMemberNames(node.expression);
+  const memberNames = ast.getMemberNames({ node: node.expression });
   return memberNames[memberNames.length - 1] === "unsafe";
-}
-
-function getTypeScriptMemberNames(node: ts.Node): string[] {
-  const expression = unwrapTypeScriptExpression(node);
-
-  if (ts.isIdentifier(expression)) {
-    return [expression.text];
-  }
-
-  if (ts.isPropertyAccessExpression(expression)) {
-    return [...getTypeScriptMemberNames(expression.expression), expression.name.text];
-  }
-
-  return [];
-}
-
-function getTypeScriptRootIdentifier(node: ts.Node): ts.Identifier | undefined {
-  const expression = unwrapTypeScriptExpression(node);
-
-  if (ts.isIdentifier(expression)) {
-    return expression;
-  }
-
-  if (ts.isPropertyAccessExpression(expression)) {
-    return getTypeScriptRootIdentifier(expression.expression);
-  }
-
-  if (ts.isCallExpression(expression)) {
-    return getTypeScriptRootIdentifier(expression.expression);
-  }
-
-  return undefined;
 }
 
 function isTypeScriptPostgresSqlIdentifier(
   identifier: ts.Identifier,
   checker: ts.TypeChecker,
 ): boolean {
-  const initializer = findTypeScriptInitializer(identifier, checker);
+  const initializer = ast.findInitializer({ identifier: identifier, checker: checker });
 
   if (initializer && isTypeScriptPostgresSqlInitializer(initializer, checker)) {
     return true;
@@ -457,7 +402,7 @@ function hasTypeScriptPostgresSymbol(type: ts.Type, checker: ts.TypeChecker): bo
   );
 
   for (const symbol of symbols) {
-    if (!isSymbolFromModule(checker, symbol, "postgres")) {
+    if (!ast.isSymbolImportedFrom({ checker, symbol, moduleName: "postgres" })) {
       continue;
     }
 
@@ -470,7 +415,7 @@ function hasTypeScriptPostgresSymbol(type: ts.Type, checker: ts.TypeChecker): bo
 }
 
 function isTypeScriptPostgresSqlInitializer(node: ts.Node, checker: ts.TypeChecker): boolean {
-  const expression = unwrapTypeScriptExpression(node);
+  const expression = ast.unwrap({ node: node });
 
   if (ts.isIdentifier(expression)) {
     return isTypeScriptPostgresSqlIdentifier(expression, checker);
@@ -480,13 +425,13 @@ function isTypeScriptPostgresSqlInitializer(node: ts.Node, checker: ts.TypeCheck
     return false;
   }
 
-  const rootIdentifier = getTypeScriptRootIdentifier(expression.expression);
+  const rootIdentifier = ast.getRootIdentifier({ node: expression.expression });
 
   if (!rootIdentifier) {
     return false;
   }
 
-  if (isTypeScriptIdentifierFromModule(rootIdentifier, checker, "postgres")) {
+  if (ast.isImportedFrom({ node: rootIdentifier, checker, moduleName: "postgres" })) {
     return true;
   }
 
@@ -495,28 +440,6 @@ function isTypeScriptPostgresSqlInitializer(node: ts.Node, checker: ts.TypeCheck
     expression.expression.name.text === "reserve"
   ) {
     return isTypeScriptPostgresTag(expression.expression.expression, checker);
-  }
-
-  return false;
-}
-
-function isTypeScriptIdentifierFromModule(
-  identifier: ts.Identifier,
-  checker: ts.TypeChecker,
-  moduleName: string,
-): boolean {
-  const symbol = checker.getSymbolAtLocation(identifier);
-
-  for (const declaration of symbol?.declarations ?? []) {
-    const importDeclaration = getTypeScriptImportDeclaration(declaration);
-
-    if (
-      importDeclaration &&
-      ts.isStringLiteral(importDeclaration.moduleSpecifier) &&
-      importDeclaration.moduleSpecifier.text === moduleName
-    ) {
-      return true;
-    }
   }
 
   return false;
@@ -566,74 +489,6 @@ function isTypeScriptTransactionSqlParameter(
   return false;
 }
 
-function getTypeScriptImportDeclaration(node: ts.Declaration): ts.ImportDeclaration | undefined {
-  if (ts.isImportClause(node) && ts.isImportDeclaration(node.parent)) {
-    return node.parent;
-  }
-
-  if (ts.isImportSpecifier(node)) {
-    const importDeclaration = node.parent.parent.parent;
-
-    if (ts.isImportDeclaration(importDeclaration)) {
-      return importDeclaration;
-    }
-  }
-
-  if (ts.isNamespaceImport(node)) {
-    const importDeclaration = node.parent.parent.parent;
-
-    if (ts.isImportDeclaration(importDeclaration)) {
-      return importDeclaration;
-    }
-  }
-
-  return undefined;
-}
-
-function isSymbolFromModule(
-  checker: ts.TypeChecker,
-  symbol: ts.Symbol | undefined,
-  moduleName: string,
-): boolean {
-  if (!symbol) {
-    return false;
-  }
-
-  const resolved = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
-
-  for (const declaration of resolved.declarations ?? []) {
-    // Normalize separators so the match holds on Windows paths (`\`) too.
-    const fileName = declaration.getSourceFile().fileName.replace(/\\/g, "/");
-
-    if (fileName.includes(`/${moduleName}/`)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function findTypeScriptInitializer(
-  identifier: ts.Identifier,
-  checker: ts.TypeChecker,
-): ts.Expression | undefined {
-  const symbol = checker.getSymbolAtLocation(identifier);
-  const resolved =
-    symbol && (symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol);
-
-  for (const declaration of resolved?.declarations ?? []) {
-    if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
-      return declaration.initializer;
-    }
-
-    if (ts.isBindingElement(declaration) && declaration.initializer) {
-      return declaration.initializer;
-    }
-  }
-
-  return undefined;
-}
-
 function isTypeScriptFragmentVariable(
   node: ts.TaggedTemplateExpression,
   checker: ts.TypeChecker,
@@ -658,7 +513,10 @@ function isTypeScriptInterpolatedAsFragment(
   identifier: ts.Identifier,
   checker: ts.TypeChecker,
 ): boolean {
-  const symbol = resolveTypeScriptSymbol(checker.getSymbolAtLocation(identifier), checker);
+  const symbol = ast.resolveAliasedSymbol({
+    checker,
+    symbol: checker.getSymbolAtLocation(identifier),
+  });
 
   if (!symbol) {
     return false;
@@ -720,7 +578,10 @@ function containsTypeScriptIdentifier(
     }
 
     if (ts.isIdentifier(current)) {
-      const currentSymbol = resolveTypeScriptSymbol(checker.getSymbolAtLocation(current), checker);
+      const currentSymbol = ast.resolveAliasedSymbol({
+        checker,
+        symbol: checker.getSymbolAtLocation(current),
+      });
 
       if (currentSymbol === symbol) {
         found = true;
@@ -733,17 +594,6 @@ function containsTypeScriptIdentifier(
 
   visit(node);
   return found;
-}
-
-function resolveTypeScriptSymbol(
-  symbol: ts.Symbol | undefined,
-  checker: ts.TypeChecker,
-): ts.Symbol | undefined {
-  if (!symbol) {
-    return undefined;
-  }
-
-  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
 }
 
 function buildSelectHelperSQL(value: StaticValue, columnNames: string[]): string | undefined {

--- a/packages/plugins/slonik/src/plugin.ts
+++ b/packages/plugins/slonik/src/plugin.ts
@@ -1,6 +1,5 @@
-import path from "path";
 import type { TSESTree } from "@typescript-eslint/utils";
-import { definePlugin, type ExpressionContext } from "@ts-safeql/plugin-utils";
+import { ast, definePlugin, type ExpressionContext } from "@ts-safeql/plugin-utils";
 import { createZodAnnotator } from "@ts-safeql/zod-annotator";
 import ts from "typescript";
 
@@ -36,14 +35,15 @@ export default definePlugin({
         },
       },
       onTarget: ({ node, context }) => {
-        const rootId = getRootIdentifier(node.tag);
+        const rootId = ast.estree.getRootIdentifier({ node: node.tag });
         if (!rootId) return undefined;
 
         const tsNode = context.parser.esTreeNodeToTSNodeMap.get(rootId);
         const symbol = tsNode ? context.checker.getSymbolAtLocation(tsNode) : undefined;
-        if (!isSlonikSymbol(context.checker, symbol)) return undefined;
+        if (!ast.isSymbolImportedFrom({ checker: context.checker, symbol, moduleName: "slonik" }))
+          return undefined;
 
-        switch (getEstreeMethodName(node.tag)) {
+        switch (ast.estree.getMethodName({ node: node.tag })) {
           case "fragment":
             return false;
           case "unsafe":
@@ -69,21 +69,6 @@ export default definePlugin({
   },
 });
 
-function getIdentifierName(
-  node: TSESTree.Expression | TSESTree.PrivateIdentifier,
-): string | undefined {
-  return node.type === "Identifier" ? node.name : undefined;
-}
-
-function getEstreeMethodName(node: TSESTree.Expression): string | undefined {
-  if (node.type === "MemberExpression") return getIdentifierName(node.property);
-  if (node.type === "CallExpression" && node.callee.type === "MemberExpression") {
-    return getIdentifierName(node.callee.property);
-  }
-
-  return undefined;
-}
-
 function translateCallExpression(
   node: TSESTree.Expression,
   tsNode: ts.Node,
@@ -92,7 +77,7 @@ function translateCallExpression(
   if (node.type !== "CallExpression") return undefined;
   if (!isSlonikCallExpression(tsNode, checker)) return undefined;
 
-  const method = getEstreeMethodName(node);
+  const method = ast.estree.getMethodName({ node });
   if (!method) return undefined;
 
   const typeCast = TYPE_CAST_MAP[method];
@@ -121,7 +106,7 @@ function translateCallExpression(
 function translateIdentifierCall(arg: TSESTree.CallExpressionArgument | undefined): string | false {
   if (arg?.type !== "ArrayExpression") return false;
 
-  const parts = getStaticStringLiterals(arg.elements);
+  const parts = ast.estree.getStringLiterals({ nodes: arg.elements });
   return parts ? joinIdentifierPath(parts) : false;
 }
 
@@ -134,7 +119,7 @@ function translateArrayCall(
     return typeof arg.value === "string" ? `$N::${arg.value}[]` : false;
   }
 
-  const current = unwrapTsNode(tsNode);
+  const current = ast.unwrap({ node: tsNode });
   return ts.isCallExpression(current) && isSlonikFragmentExpression(current.arguments[1], checker)
     ? "$N"
     : false;
@@ -143,44 +128,12 @@ function translateArrayCall(
 function translateUnnestCall(arg: TSESTree.CallExpressionArgument | undefined): string | false {
   if (arg?.type !== "ArrayExpression") return false;
 
-  const parts = getStaticStringLiterals(arg.elements);
+  const parts = ast.estree.getStringLiterals({ nodes: arg.elements });
   if (!parts) return false;
 
   const types = parts.map((part) => `$N::${part}[]`);
 
   return types.length > 0 ? `unnest(${types.join(", ")})` : false;
-}
-
-function getRootIdentifier(node: TSESTree.Expression): TSESTree.Identifier | undefined {
-  if (node.type === "Identifier") return node;
-  if (node.type === "MemberExpression") return getRootIdentifier(node.object);
-  if (node.type === "CallExpression") return getRootIdentifier(node.callee);
-  return undefined;
-}
-
-function isSlonikSymbol(checker: ts.TypeChecker, symbol: ts.Symbol | undefined): boolean {
-  if (!symbol) return false;
-
-  const candidates = getSymbolCandidates(checker, symbol);
-  if (candidates.some((candidate) => isImportedFromModule(candidate, "slonik"))) return true;
-
-  // Re-exports (e.g. `export { sql } from "slonik"`) leave the import chain
-  // detached from user code, so fall back to inspecting the declaration's
-  // source file. Require the file to live inside a `node_modules/slonik` tree
-  // so user files under e.g. `src/slonik/` don't trigger false positives.
-  return candidates.some((candidate) =>
-    (candidate.declarations ?? []).some((declaration) =>
-      isSlonikPackageFile(declaration.getSourceFile().fileName),
-    ),
-  );
-}
-
-function isSlonikPackageFile(fileName: string): boolean {
-  const parts = path.normalize(fileName).split(path.sep);
-  for (let i = 0; i < parts.length - 1; i++) {
-    if (parts[i] === "node_modules" && parts[i + 1] === "slonik") return true;
-  }
-  return false;
 }
 
 function isFragmentTokenType(context: ExpressionContext): boolean {
@@ -203,14 +156,15 @@ function resolveFragmentSql(
   checker: ts.TypeChecker,
   visited = new Set<ts.Symbol>(),
 ): string | false | undefined {
-  const expression = unwrapTsNode(node);
+  const expression = ast.unwrap({ node: node });
 
   if (ts.isIdentifier(expression)) {
     return resolveIdentifierFragmentSql(expression, checker, visited);
   }
 
   if (ts.isTaggedTemplateExpression(expression)) {
-    return getTsMethodName(expression.tag) === "fragment" && isSlonikMethod(expression.tag, checker)
+    return ast.getMethodName({ node: expression.tag }) === "fragment" &&
+      isSlonikMethod(expression.tag, checker)
       ? buildFragmentTemplateSql(expression.template, checker, visited)
       : undefined;
   }
@@ -232,33 +186,16 @@ function quoteLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
-function isImportedFromModule(symbol: ts.Symbol, moduleName: string): boolean {
-  return (symbol.declarations ?? []).some((declaration) => {
-    let current: ts.Node | undefined = declaration;
-    while (current && !ts.isImportDeclaration(current)) current = current.parent;
-
-    return (
-      current?.moduleSpecifier &&
-      ts.isStringLiteralLike(current.moduleSpecifier) &&
-      current.moduleSpecifier.text === moduleName
-    );
-  });
-}
-
-function getSymbolCandidates(checker: ts.TypeChecker, symbol: ts.Symbol): ts.Symbol[] {
-  const resolved = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
-  return resolved === symbol ? [symbol] : [symbol, resolved];
-}
-
 function isSlonikCallExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
-  const current = unwrapTsNode(node);
+  const current = ast.unwrap({ node: node });
   return ts.isCallExpression(current) && isSlonikMethod(current.expression, checker);
 }
 
 function isSlonikFragmentExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
-  const current = unwrapTsNode(node);
+  const current = ast.unwrap({ node: node });
   return ts.isTaggedTemplateExpression(current)
-    ? getTsMethodName(current.tag) === "fragment" && isSlonikMethod(current.tag, checker)
+    ? ast.getMethodName({ node: current.tag }) === "fragment" &&
+        isSlonikMethod(current.tag, checker)
     : false;
 }
 
@@ -270,7 +207,7 @@ function resolveIdentifierFragmentSql(
   const symbol = checker.getSymbolAtLocation(node);
   if (!symbol) return undefined;
 
-  const candidates = getSymbolCandidates(checker, symbol);
+  const candidates = ast.getSymbolCandidates({ checker: checker, symbol: symbol });
   if (candidates.some((candidate) => visited.has(candidate))) return undefined;
 
   const nextVisited = new Set(visited);
@@ -289,7 +226,7 @@ function resolveIdentifierFragmentSql(
 
     if (!ts.isBindingElement(declaration)) continue;
 
-    const initializer = resolveBindingElementInitializer(declaration);
+    const initializer = ast.getBindingInitializer({ element: declaration });
     if (!initializer) continue;
 
     const resolved = resolveFragmentSql(initializer, checker, new Set(nextVisited));
@@ -297,64 +234,6 @@ function resolveIdentifierFragmentSql(
   }
 
   return undefined;
-}
-
-function resolveBindingElementInitializer(element: ts.BindingElement): ts.Expression | undefined {
-  if (element.dotDotDotToken) return undefined;
-
-  const source = getBindingSource(element.parent);
-  if (!source) return undefined;
-
-  if (ts.isObjectBindingPattern(element.parent)) {
-    return resolveObjectBindingElementInitializer(element, source);
-  }
-
-  if (ts.isArrayBindingPattern(element.parent)) {
-    return resolveArrayBindingElementInitializer(element, source);
-  }
-
-  return undefined;
-}
-
-function getBindingSource(pattern: ts.BindingPattern): ts.Expression | undefined {
-  const owner = pattern.parent;
-
-  if (ts.isVariableDeclaration(owner)) return owner.initializer;
-  if (ts.isBindingElement(owner)) return resolveBindingElementInitializer(owner);
-
-  return undefined;
-}
-
-function resolveObjectBindingElementInitializer(
-  element: ts.BindingElement,
-  source: ts.Expression,
-): ts.Expression | undefined {
-  if (!ts.isObjectLiteralExpression(source)) return undefined;
-
-  const propertyName = getTsPropertyName(element.propertyName ?? element.name);
-  if (!propertyName) return undefined;
-
-  const property = source.properties.find(
-    (candidate): candidate is ts.PropertyAssignment | ts.ShorthandPropertyAssignment =>
-      (ts.isPropertyAssignment(candidate) || ts.isShorthandPropertyAssignment(candidate)) &&
-      getTsPropertyName(candidate.name) === propertyName,
-  );
-
-  if (!property) return undefined;
-  return ts.isPropertyAssignment(property) ? property.initializer : property.name;
-}
-
-function resolveArrayBindingElementInitializer(
-  element: ts.BindingElement,
-  source: ts.Expression,
-): ts.Expression | undefined {
-  if (!ts.isArrayLiteralExpression(source)) return undefined;
-
-  const index = element.parent.elements.indexOf(element);
-  if (index < 0) return undefined;
-
-  const value = source.elements[index];
-  return value && !ts.isOmittedExpression(value) && !ts.isSpreadElement(value) ? value : undefined;
 }
 
 function buildFragmentTemplateSql(
@@ -381,7 +260,7 @@ function resolveFragmentFactoryCall(
   node: ts.CallExpression,
   checker: ts.TypeChecker,
 ): string | false | undefined {
-  const method = getTsMethodName(node);
+  const method = ast.getMethodName({ node });
   if (!method || !isSlonikMethod(node.expression, checker)) return undefined;
 
   switch (method) {
@@ -399,85 +278,12 @@ function resolveFragmentFactoryCall(
 }
 
 function isSlonikMethod(node: ts.Expression, checker: ts.TypeChecker): boolean {
-  const root = getTsRootIdentifier(node);
-  return root ? isSlonikSymbol(checker, checker.getSymbolAtLocation(root)) : false;
-}
-
-function getTsMethodName(node: ts.Node): string | undefined {
-  const current = unwrapTsNode(node);
-
-  if (ts.isPropertyAccessExpression(current)) return current.name.text;
-  if (ts.isCallExpression(current) && ts.isPropertyAccessExpression(current.expression)) {
-    return current.expression.name.text;
-  }
-
-  return undefined;
-}
-
-function getTsRootIdentifier(node: ts.Expression): ts.Identifier | undefined {
-  const current = unwrapTsNode(node);
-
-  if (ts.isIdentifier(current)) return current;
-  if (ts.isPropertyAccessExpression(current)) return getTsRootIdentifier(current.expression);
-  if (ts.isCallExpression(current)) return getTsRootIdentifier(current.expression);
-
-  return undefined;
-}
-
-function unwrapTsNode(node: ts.Node): ts.Node {
-  let current = node;
-
-  while (
-    ts.isAsExpression(current) ||
-    ts.isNonNullExpression(current) ||
-    ts.isParenthesizedExpression(current) ||
-    ts.isSatisfiesExpression(current)
-  ) {
-    current = current.expression;
-  }
-
-  return current;
-}
-
-function getTsPropertyName(node: ts.PropertyName | ts.BindingName): string | undefined {
-  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return node.text;
-  if (ts.isStringLiteralLike(node) || ts.isNumericLiteral(node)) return node.text;
-  return undefined;
+  return ast.isImportedFrom({ node: node, checker: checker, moduleName: "slonik" });
 }
 
 function translateTsIdentifierCall(arg: ts.Expression | undefined): string | false {
   if (!arg || !ts.isArrayLiteralExpression(arg)) return false;
 
-  const parts = getStaticTsStrings(arg.elements);
+  const parts = ast.getStringLiterals({ nodes: arg.elements });
   return parts ? joinIdentifierPath(parts) : false;
-}
-
-function getStaticStringLiterals(
-  elements: readonly (TSESTree.Expression | TSESTree.SpreadElement | null)[],
-): string[] | undefined {
-  const parts: string[] = [];
-
-  for (const element of elements) {
-    if (element?.type !== "Literal" || typeof element.value !== "string") {
-      return undefined;
-    }
-
-    parts.push(element.value);
-  }
-
-  return parts;
-}
-
-function getStaticTsStrings(elements: readonly ts.Node[]): string[] | undefined {
-  const parts: string[] = [];
-
-  for (const element of elements) {
-    if (!ts.isStringLiteralLike(element)) {
-      return undefined;
-    }
-
-    parts.push(element.text);
-  }
-
-  return parts;
 }


### PR DESCRIPTION
Adds a shared TypeScript-AST toolkit to `@ts-safeql/plugin-utils` so plugins stop re-implementing the same node/symbol/static-evaluation logic, and refactors the existing **slonik** and **postgres-js** plugins onto it.

- New `ast.*` toolkit: symbol origin, static evaluation, node unwrapping, destructuring/member-name resolution, plus ESTree-node mirrors (`ast.estree.*`).
- slonik and postgres-js now use the toolkit; their duplicated local helpers are removed.
- Establishes the plugin API surface that later plugin PRs build on.

Foundational, no behavior change — existing plugin tests pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional plugin migration hook and migration resolution alongside existing connection resolution.
  * Expanded the public plugin utility API with sourcemap-aware query metadata and new rule/checker-side resolution hooks.
  * Introduced a shared AST toolkit for root/method name extraction, static value evaluation, initializer lookup, and import/alias origin checks.

* **Refactor**
  * Updated PostgreSQL and Slonik plugins to use the shared AST toolkit for expression and fragment/identifier analysis.

* **Tests**
  * Added compile-time contract tests for plugin utility TypeScript types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->