### PR TITLE
feat(docs): redesign landing page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,6 +4,19 @@ import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 export default defineConfig({
   title: "SafeQL",
   description: "Write SQL queries with confidence!",
+  appearance: "dark",
+
+  head: [
+    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+    ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
+    [
+      "link",
+      {
+        rel: "stylesheet",
+        href: "https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&family=Geist+Mono:wght@400;500;600&display=swap",
+      },
+    ],
+  ],
   markdown: {
     theme: {
       dark: "material-theme-ocean",
@@ -24,7 +37,7 @@ export default defineConfig({
     editLink: {
       pattern: "https://github.com/ts-safeql/safeql/tree/main/docs/:path",
     },
-    logo: "/ts-logo.svg",
+    logo: "/safeql-logo.svg",
     sidebar: [
       {
         text: "Guide",
@@ -125,8 +138,8 @@ export default defineConfig({
         link: "https://github.com/ts-safeql/safeql",
       },
       {
-        icon: "twitter",
-        link: "https://twitter.com/CoEliya",
+        icon: "x",
+        link: "https://x.com/CoEliya",
       },
     ],
   },

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,31 +1,12 @@
 <script setup>
 import DefaultTheme from "vitepress/theme";
-import Comments from './components/Comments.vue'
+import Comments from "./components/Comments.vue";
 </script>
 
 <template>
   <DefaultTheme.Layout>
-    <template #home-hero-image>
-      <video autoplay loop muted src="/video.mp4" class="video" />
-    </template>
     <template #doc-after>
       <Comments />
     </template>
   </DefaultTheme.Layout>
 </template>
-
-<style scoped>
-.video {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  max-height: 192px;
-  transform: translate(-50%, -50%);
-}
-
-@media (min-width: 640px) {
-  .video {
-    max-height: unset;
-  }
-}
-</style>

--- a/docs/.vitepress/theme/components/landing/CodeMorph.vue
+++ b/docs/.vitepress/theme/components/landing/CodeMorph.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { shallowRef, onMounted, computed } from "vue";
+import { useData } from "vitepress";
+import { ShikiMagicMove } from "shiki-magic-move/vue";
+import "shiki-magic-move/style.css";
+import { getHighlighter } from "./highlighter";
+
+defineProps({
+  code: { type: String, default: "" },
+  splitTokens: { type: Boolean, default: true },
+});
+const emit = defineEmits(["ready", "morphend"]);
+
+const { isDark } = useData();
+const theme = computed(() => (isDark.value ? "safeql-dark" : "safeql-light"));
+
+const hl = shallowRef(null);
+onMounted(async () => {
+  hl.value = await getHighlighter();
+  emit("ready");
+});
+function onEnd() {
+  emit("morphend");
+}
+</script>
+
+<template>
+  <ShikiMagicMove
+    v-if="hl"
+    lang="ts"
+    :theme="theme"
+    :highlighter="hl"
+    :code="code"
+    :options="{ duration: 650, stagger: 0.06, lineNumbers: false, animateContainer: true, splitTokens }"
+    @end="onEnd"
+  />
+</template>

--- a/docs/.vitepress/theme/components/landing/EditorDemo.vue
+++ b/docs/.vitepress/theme/components/landing/EditorDemo.vue
@@ -1,0 +1,640 @@
+<script setup>
+import { onMounted, onBeforeUnmount, watch, ref, computed, defineAsyncComponent } from "vue";
+
+const CodeMorph = defineAsyncComponent(() => import("./CodeMorph.vue"));
+
+const props = defineProps({
+  scene: { type: Number, default: 0 },
+  auto: { type: Boolean, default: false },
+  cycle: { type: Array, default: () => [0, 1, 2] },
+  compact: { type: Boolean, default: false },
+});
+const emit = defineEmits(["progress", "done"]);
+
+const root = ref(null);
+const demoRoot = ref(null);
+const editor = ref(null);
+const code = ref(null);
+const hover = ref(null);
+const cursor = ref(null);
+const squig = ref(null);
+let squigW = 0;
+const errCount = ref(null);
+const errDot = ref(null);
+
+const fileLabel = ref("users.ts");
+const autoStep = ref(0);
+const autoProg = ref(0);
+
+let io = null;
+let tl = null;
+let gap = null;
+let visible = false;
+let gsapRef = null;
+let gsapReady = false;
+let morphReady = false;
+let started = false;
+let autoPos = 0;
+
+const H0_A = "function getUsers() {\n  return sql`\n    SELECT idd FROM users\n  `;\n}";
+const H0_B = "function getUsers() {\n  return sql`\n    SELECT id FROM users\n  `;\n}";
+const H1_A = "function getUsers() {\n  return sql`\n    SELECT id, email FROM users\n  `;\n}";
+const H1_B = "function getUsers() {\n  return sql<{ id: number; email: string }>`\n    SELECT id, email FROM users\n  `;\n}";
+const H2_A = "function getUsers() {\n  return sql<{ id: string }>`\n    SELECT id FROM users\n  `;\n}";
+const H2_B = "function getUsers() {\n  return sql<{ id: number }>`\n    SELECT id FROM users\n  `;\n}";
+
+const A1_A = "function postStats() {\n  return sql<{ author_id: number; posts: number }>`\n    SELECT author_id, count(*) AS posts\n    FROM posts\n    GROUP BY status\n  `;\n}";
+const A1_B = "function postStats() {\n  return sql<{ author_id: number; posts: number }>`\n    SELECT author_id, count(*) AS posts\n    FROM posts\n    GROUP BY author_id\n  `;\n}";
+const A1_C = "function postStats() {\n  return sql<{ author_id: number; posts: string }>`\n    SELECT author_id, count(*) AS posts\n    FROM posts\n    GROUP BY author_id\n  `;\n}";
+
+const C_PG_A = "function postgresJs() {\n  return sql`\n    SELECT idd FROM users\n  `;\n}";
+const C_PG_B = "function postgresJs() {\n  return sql`\n    SELECT id FROM users\n  `;\n}";
+const C_SLO_A = "function slonik() {\n  return sql.type(z.object({ id: z.string() }))`\n    SELECT id FROM users\n  `;\n}";
+const C_SLO_B = "function slonik() {\n  return sql.type(z.object({ id: z.number() }))`\n    SELECT id FROM users\n  `;\n}";
+const C_PRI_A = "function prisma() {\n  return prisma.$queryRaw`\n    SELECT emial FROM users\n  `;\n}";
+const C_PRI_B = "function prisma() {\n  return prisma.$queryRaw`\n    SELECT email FROM users\n  `;\n}";
+
+const INC_A = "const $typedSql = sql;\n\nconst a = await sql`SELECT idd FROM users`;\nconst b = await sql`SELECT id FROM posts`;";
+const INC_B = "const $typedSql = sql;\n\nconst a = await $typedSql`SELECT idd FROM users`;\nconst b = await sql`SELECT id FROM posts`;";
+const INC_C = "const $typedSql = sql;\n\nconst a = await $typedSql`SELECT id FROM users`;\nconst b = await sql`SELECT id FROM posts`;";
+
+const EXT_A = "connections({\n  plugins: [awsIamAuth()],\n  targets: [{ tag: \"sql\" }],\n});";
+const EXT_B = "connections({\n  plugins: [awsIamAuth(), slonik()],\n  targets: [{ tag: \"sql\" }],\n});";
+const EXT_C = "connections({\n  plugins: [awsIamAuth(), slonik(), myCustomPlugin()],\n  targets: [{ tag: \"sql\" }],\n});";
+
+const SCENES = [
+  {
+    label: "Catches mistakes",
+    file: "users.ts",
+    code: H0_A,
+    acts: [{ t: "error", find: ["idd", 1], msg: "column <b>idd</b> does not exist — did you mean <b>id</b>?", hold: 2.6, fix: H0_B, clear: true }],
+  },
+  {
+    label: "Infers result types",
+    file: "users.ts",
+    code: H1_A,
+    acts: [{ t: "error", find: ["sql", 1], msg: "query is missing its type annotation", hold: 2.4, fix: H1_B, clear: true }],
+  },
+  {
+    label: "Auto-fixes types",
+    file: "users.ts",
+    code: H2_A,
+    acts: [{ t: "error", find: ["string", 1], msg: "incorrect type annotation — expected <b>number</b>", hold: 2.4, fix: H2_B, clear: true }],
+  },
+  {
+    file: "stats.ts",
+    code: A1_A,
+    acts: [
+      { t: "error", find: ["author_id", 2], msg: "column <b>author_id</b> must appear in the <b>GROUP BY</b> clause", hold: 2.7, fix: A1_B },
+      { t: "error", find: ["number", 2], msg: "<b>count(*)</b> is <b>bigint</b> — typed as <b>string</b>", hold: 2.7, fix: A1_C, clear: true },
+    ],
+  },
+  {
+    file: "queries.ts",
+    code: C_PG_A,
+    acts: [
+      { t: "error", find: ["idd", 1], msg: "<b>postgres.js</b> — column <b>idd</b> does not exist, did you mean <b>id</b>?", hold: 2.4, fix: C_PG_B, clear: true },
+      { t: "code", to: C_SLO_A },
+      { t: "error", find: ["z.string", 1], msg: "<b>Slonik</b> — Zod schema doesn't match, expected <b>z.number()</b>", hold: 2.5, fix: C_SLO_B, clear: true },
+      { t: "code", to: C_PRI_A },
+      { t: "error", find: ["emial", 1], msg: "<b>Prisma</b> — column <b>emial</b> does not exist, did you mean <b>email</b>?", hold: 2.4, fix: C_PRI_B, clear: true },
+    ],
+  },
+  {
+    file: "db.ts",
+    code: INC_A,
+    acts: [
+      { t: "info", find: ["$typedSql", 1], msg: "Alias your query tag once, then migrate one call at a time — the rest stay untouched.", hold: 2.6 },
+      { t: "code", to: INC_B },
+      { t: "error", find: ["idd", 1], msg: "now checked — column <b>idd</b> does not exist, did you mean <b>id</b>?", hold: 2.8, fix: INC_C, clear: true },
+    ],
+  },
+  {
+    file: "eslint.config.js",
+    code: EXT_A,
+    acts: [
+      { t: "info", find: ["awsIamAuth", 1], msg: "<b>plugin-auth-aws</b> — connect to RDS with IAM.", hold: 2.4 },
+      { t: "code", to: EXT_B },
+      { t: "info", find: ["slonik", 1], msg: "<b>plugin-slonik</b> — full Slonik support.", hold: 2.4 },
+      { t: "code", to: EXT_C },
+      { t: "info", find: ["myCustomPlugin", 1], msg: "…or your own — connection, helper &amp; migration hooks.", hold: 2.8 },
+    ],
+  },
+];
+
+const srcCode = ref(SCENES[props.auto ? props.cycle[0] : props.scene].code);
+// Custom gutter: Magic Move's own lineNumbers break splitTokens' offset math.
+// Relies on no within-scene fix ever changing the line count.
+const lineCount = computed(() => srcCode.value.split("\n").length);
+
+function setErr(n) {
+  if (errCount.value) errCount.value.textContent = n;
+  if (errDot.value) errDot.value.style.color = n > 0 ? "#d9706f" : "#4b4b52";
+}
+
+function findRange(find) {
+  const [needle, nth = 1] = Array.isArray(find) ? find : [find, 1];
+  const container = code.value;
+  if (!container) return null;
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      let el = node.parentElement;
+      while (el && el !== container) {
+        if (el.classList && el.classList.contains("shiki-magic-move-line-number")) return NodeFilter.FILTER_REJECT;
+        el = el.parentElement;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  const nodes = [];
+  let full = "";
+  let n;
+  while ((n = walker.nextNode())) {
+    nodes.push({ node: n, start: full.length });
+    full += n.nodeValue;
+  }
+  let idx = -1;
+  for (let c = 0; c < nth; c++) {
+    idx = full.indexOf(needle, idx + 1);
+    if (idx === -1) return null;
+  }
+  const end = idx + needle.length;
+  const locate = (pos) => {
+    for (const nd of nodes) {
+      if (pos >= nd.start && pos <= nd.start + nd.node.nodeValue.length) return { node: nd.node, offset: pos - nd.start };
+    }
+    return null;
+  };
+  const a = locate(idx);
+  const b = locate(end);
+  if (!a || !b) return null;
+  const range = document.createRange();
+  range.setStart(a.node, a.offset);
+  range.setEnd(b.node, b.offset);
+  return range;
+}
+
+function rectOf(find) {
+  const range = findRange(find);
+  if (!range || !demoRoot.value) return null;
+  const r = range.getBoundingClientRect();
+  const o = demoRoot.value.getBoundingClientRect();
+  return { left: r.left - o.left, top: r.top - o.top, right: r.right - o.left, bottom: r.bottom - o.top, width: r.width, height: r.height };
+}
+
+function showSquiggle(rect, gsap) {
+  if (!rect) return;
+  // animate width (not scaleX, which would distort the wave shape)
+  squigW = Math.max(rect.width, 8);
+  gsap.set(squig.value, { left: rect.left, top: rect.bottom + 1, width: 0 });
+}
+
+function placeAt(rect) {
+  if (!rect) return;
+  const o = demoRoot.value.getBoundingClientRect();
+  const hw = hover.value.offsetWidth;
+  const maxLeft = window.innerWidth - o.left - hw - 8;
+  const left = Math.max(8 - o.left, Math.min(rect.left, maxLeft));
+  hover.value.style.left = left + "px";
+  hover.value.style.top = rect.bottom + 11 + "px";
+  hover.value.classList.add("below");
+  hover.value.classList.remove("above");
+}
+
+function setInfo(text) {
+  hover.value.classList.add("info");
+  hover.value.innerHTML =
+    `<div class="hv-info"><svg class="hv-ic" viewBox="0 0 16 16" width="15" height="15" aria-hidden="true"><circle cx="8" cy="8" r="6.6" fill="none" stroke="currentColor" stroke-width="1.4" /><path d="M8 7.1v3.5M8 5.1v.1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" /></svg><span>${text}</span></div>`;
+}
+function setPopover(msg) {
+  hover.value.classList.remove("info");
+  hover.value.innerHTML =
+    `<div class="hv-top"><span class="hv-msg">${msg}</span> <span class="hv-rule">eslint(<a>@ts-safeql/check-sql</a>)</span></div>` +
+    `<div class="hv-actions"><span class="hv-act">View Problem <kbd>F2</kbd></span><span class="hv-act qf">Quick Fix… <kbd>⌘.</kbd></span></div>`;
+}
+function quickFixPos() {
+  const o = demoRoot.value.getBoundingClientRect();
+  const r = hover.value.querySelector(".qf").getBoundingClientRect();
+  return { x: r.left - o.left + r.width / 2, y: r.top - o.top + r.height / 2 };
+}
+function addAutofix(t, gsap, rectFn, applyFn) {
+  let fx = 0, fy = 0;
+  t.add(() => {
+    const p = quickFixPos();
+    fx = p.x;
+    fy = p.y;
+    const rect = rectFn() || { left: 0, bottom: 0, width: 0 };
+    gsap.set(cursor.value, { left: rect.left + Math.min(rect.width, 90), top: rect.bottom + 4, opacity: 0, scale: 1 });
+  })
+    .to(cursor.value, { opacity: 1, duration: 0.2 })
+    .to(cursor.value, { left: () => fx, top: () => fy, duration: 0.6, ease: "power2.inOut" })
+    .to(cursor.value, { scale: 0.8, duration: 0.1 })
+    .to(cursor.value, { scale: 1, duration: 0.12 })
+    .add(applyFn)
+    .to(hover.value, { opacity: 0, y: 6, duration: 0.25 }, "<")
+    .to(cursor.value, { opacity: 0, duration: 0.25 }, "<");
+}
+
+function appendAct(t, gsap, act) {
+  if (act.t === "code") {
+    // cross-fade whole-block swaps; a char-level morph of an unrelated block scrambles
+    t.to(code.value, { opacity: 0, duration: 0.28 })
+      .add(() => { srcCode.value = act.to; })
+      .to({}, { duration: 0.72 })
+      .to(code.value, { opacity: 1, duration: 0.3 });
+    return;
+  }
+  if (act.t === "info") {
+    t.add(() => { setInfo(act.msg); placeAt(rectOf(act.find)); })
+      .to(hover.value, { opacity: 1, y: 0, scale: 1, duration: 0.35 })
+      .to({}, { duration: act.hold ?? 2.6 })
+      .to(hover.value, { opacity: 0, y: 6, duration: 0.3 });
+    return;
+  }
+  if (act.t === "error") {
+    t.add(() => { setErr(1); showSquiggle(rectOf(act.find), gsap); })
+      .to(squig.value, { width: () => squigW, opacity: 1, duration: 0.4, ease: "none" })
+      .add(() => { setPopover(act.msg); placeAt(rectOf(act.find)); })
+      .to(hover.value, { opacity: 1, y: 0, scale: 1, duration: 0.35 })
+      .to({}, { duration: act.hold ?? 2.6 });
+    if (act.fix) {
+      // morph the fix in place (hero is char-level, feature is token-level)
+      addAutofix(t, gsap, () => rectOf(act.find), () => {
+        srcCode.value = act.fix;
+        gsap.set(squig.value, { width: 0, opacity: 0 });
+        if (act.clear) setErr(0);
+      });
+      t.to({}, { duration: 0.95 });
+    } else {
+      t.to(hover.value, { opacity: 0, y: 6, duration: 0.3 })
+        .to(squig.value, { opacity: 0, duration: 0.3 }, "<")
+        .add(() => { if (act.clear !== false) setErr(0); });
+    }
+    return;
+  }
+}
+
+function buildScene(i, gsap) {
+  const s = SCENES[i];
+  gsap.set(hover.value, { opacity: 0, y: 6, scale: 0.98 });
+  gsap.set(cursor.value, { opacity: 0 });
+  gsap.set(squig.value, { opacity: 0, width: 0 });
+  setErr(0);
+  const enter = () => { srcCode.value = s.code; fileLabel.value = s.file; setErr(0); };
+  const t = gsap.timeline({ defaults: { ease: "power2.out" } });
+  if (started && !props.auto) {
+    t.to(code.value, { opacity: 0, duration: 0.3 })
+      .add(enter)
+      .to({}, { duration: 0.72 })
+      .to(code.value, { opacity: 1, duration: 0.3 });
+  } else {
+    started = true;
+    t.add(enter).set(code.value, { opacity: 1 }).to({}, { duration: 0.65 });
+  }
+  s.acts.forEach((act) => appendAct(t, gsap, act));
+  t.to({}, { duration: 0.6 });
+  return t;
+}
+
+function sceneIndex() {
+  return props.auto ? props.cycle[autoPos % props.cycle.length] : props.scene;
+}
+const ready = () => gsapReady && morphReady;
+
+function play() {
+  if (!ready() || !gsapRef) return;
+  const i = sceneIndex();
+  if (props.auto) autoStep.value = autoPos % props.cycle.length;
+  if (!visible || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    fileLabel.value = SCENES[i].file;
+    srcCode.value = SCENES[i].code;
+    gsapRef.set(code.value, { opacity: 1 });
+    return;
+  }
+  tl = buildScene(i, gsapRef);
+  if (props.auto) {
+    autoProg.value = 0;
+    tl.eventCallback("onUpdate", () => (autoProg.value = tl.progress()));
+  } else {
+    emit("progress", 0);
+    tl.eventCallback("onUpdate", () => emit("progress", tl.progress()));
+  }
+  tl.eventCallback("onComplete", () => {
+    if (!visible) return;
+    if (props.auto) {
+      autoPos++;
+      gap = gsapRef.delayedCall(0.12, play);
+    } else {
+      emit("done");
+    }
+  });
+}
+
+function restart() {
+  if (tl) tl.kill();
+  if (gap) gap.kill();
+  play();
+}
+function jumpAuto(k) {
+  if (!props.auto) return;
+  autoPos = k;
+  restart();
+}
+function onMorphReady() {
+  if (morphReady) return;
+  morphReady = true;
+  if (visible) restart();
+}
+
+watch(
+  () => props.scene,
+  () => {
+    if (!props.auto) restart();
+  }
+);
+
+onMounted(async () => {
+  if (typeof window === "undefined") return;
+  const { gsap } = await import("gsap");
+  gsapRef = gsap;
+  gsapReady = true;
+
+  io = new IntersectionObserver(
+    ([e]) => {
+      visible = e.isIntersecting;
+      if (visible) restart();
+      else {
+        if (tl) tl.pause();
+        if (gap) gap.kill();
+      }
+    },
+    { threshold: 0.25 }
+  );
+  io.observe(root.value);
+  if (visible && morphReady) restart();
+});
+
+onBeforeUnmount(() => {
+  if (io) io.disconnect();
+  if (tl) tl.kill();
+  if (gap) gap.kill();
+});
+</script>
+
+<template>
+  <div ref="demoRoot" class="demo">
+    <div ref="root" class="vsc" :class="{ compact }" role="img" aria-label="An editor showing SafeQL checking SQL against your schema.">
+      <div class="vsc-title">
+        <span class="lights"><i /><i /><i /></span>
+        <span class="vsc-name">{{ fileLabel }}</span>
+        <span class="lights-spacer" />
+      </div>
+
+      <div class="vsc-main">
+        <div class="vsc-act" aria-hidden="true">
+          <svg viewBox="0 0 24 24" class="on"><path d="M7.5 22.5H17.595C17.07 23.4 16.11 24 15 24H7.5C4.185 24 1.5 21.315 1.5 18V6C1.5 4.89 2.1 3.93 3 3.405V18C3 20.475 5.025 22.5 7.5 22.5ZM21 8.121V18C21 19.6545 19.6545 21 18 21H7.5C5.8455 21 4.5 19.6545 4.5 18V3C4.5 1.3455 5.8455 0 7.5 0H12.879C13.4715 0 14.0505 0.24 14.4705 0.6585L20.3415 6.5295C20.766 6.954 21 7.5195 21 8.121ZM13.5 6.75C13.5 7.164 13.8375 7.5 14.25 7.5H19.1895L13.5 1.8105V6.75ZM19.5 18V9H14.25C13.0095 9 12 7.9905 12 6.75V1.5H7.5C6.672 1.5 6 2.1735 6 3V18C6 18.8265 6.672 19.5 7.5 19.5H18C18.828 19.5 19.5 18.8265 19.5 18Z" /></svg>
+          <svg viewBox="0 0 16 16"><path d="M10.0195 10.7266C9.06578 11.5217 7.83875 12 6.5 12C3.46243 12 1 9.53757 1 6.5C1 3.46243 3.46243 1 6.5 1C9.53757 1 12 3.46243 12 6.5C12 7.83875 11.5217 9.06578 10.7266 10.0195L13.8535 13.1464C14.0488 13.3417 14.0488 13.6583 13.8535 13.8536C13.6583 14.0488 13.3417 14.0488 13.1464 13.8536L10.0195 10.7266ZM11 6.5C11 4.01472 8.98528 2 6.5 2C4.01472 2 2 4.01472 2 6.5C2 8.98528 4.01472 11 6.5 11C8.98528 11 11 8.98528 11 6.5Z" /></svg>
+          <svg viewBox="0 0 24 24"><path d="M21 8.25C21 6.1815 19.3185 4.5 17.25 4.5C15.1815 4.5 13.5 6.1815 13.5 8.25C13.5 10.023 14.739 11.5035 16.395 11.892C16.116 12.819 15.2655 13.5 14.25 13.5H9.75C8.9025 13.5 8.1285 13.7925 7.5 14.268V7.4235C9.21 7.0755 10.5 5.5605 10.5 3.75C10.5 1.6815 8.8185 0 6.75 0C4.6815 0 3 1.6815 3 3.75C3 5.562 4.29 7.0755 6 7.4235V16.575C4.29 16.923 3 18.438 3 20.2485C3 22.317 4.6815 23.9985 6.75 23.9985C8.8185 23.9985 10.5 22.317 10.5 20.2485C10.5 18.4755 9.261 16.995 7.605 16.6065C7.884 15.6795 8.7345 14.9985 9.75 14.9985H14.25C16.0845 14.9985 17.61 13.6725 17.931 11.9295C19.674 11.607 21 10.0845 21 8.25ZM4.5 3.75C4.5 2.5095 5.5095 1.5 6.75 1.5C7.9905 1.5 9 2.5095 9 3.75C9 4.9905 7.9905 6 6.75 6C5.5095 6 4.5 4.9905 4.5 3.75ZM9 20.25C9 21.4905 7.9905 22.5 6.75 22.5C5.5095 22.5 4.5 21.4905 4.5 20.25C4.5 19.0095 5.5095 18 6.75 18C7.9905 18 9 19.0095 9 20.25ZM17.25 10.5C16.0095 10.5 15 9.4905 15 8.25C15 7.0095 16.0095 6 17.25 6C18.4905 6 19.5 7.0095 19.5 8.25C19.5 9.4905 18.4905 10.5 17.25 10.5Z" /></svg>
+          <svg viewBox="0 0 16 16"><path d="M15 4.95703C15 4.58711 14.8563 4.24054 14.5949 3.97992L12.0096 1.39234C11.4879 0.86922 10.5788 0.86922 10.0571 1.39234L8 3.45119V3.32321C8 2.55068 7.37187 1.922 6.6 1.922H2.4C1.62813 1.922 1 2.55068 1 3.32321V13.5988C1 14.3713 1.62813 15 2.4 15H12.6667C13.4385 15 14.0667 14.3713 14.0667 13.5988V9.39514C14.0667 8.62261 13.4385 7.99393 12.6667 7.99393H12.5379L14.5949 5.93508C14.8553 5.67445 15 5.32602 15 4.95703ZM2.4 2.85521H6.6C6.85667 2.85521 7.06667 3.06446 7.06667 3.32228V7.99299H1.93333V3.32228C1.93333 3.06446 2.14333 2.85521 2.4 2.85521ZM1.93333 13.5979V8.92714H7.06667V14.0649H2.4C2.14333 14.0649 1.93333 13.8547 1.93333 13.5979ZM13.1333 9.39421V13.5979C13.1333 13.8547 12.9233 14.0649 12.6667 14.0649H8V8.92714H12.6667C12.9233 8.92714 13.1333 9.13638 13.1333 9.39421ZM8 7.99299V6.46287L9.5288 7.99299H8ZM13.9351 5.2737L11.3488 7.86221C11.1789 8.03223 10.8859 8.03223 10.716 7.86221L8.12973 5.2737C8.0448 5.18963 7.99813 5.07753 7.99813 4.95796C7.99813 4.83839 8.0448 4.7263 8.12973 4.64129L10.716 2.05278C10.8009 1.96777 10.9129 1.92106 11.0324 1.92106C11.1519 1.92106 11.2639 1.96777 11.3488 2.05278L13.9351 4.64129C14.02 4.72536 14.0667 4.83746 14.0667 4.95703C14.0667 5.0766 14.02 5.1887 13.9351 5.2737Z" /></svg>
+        </div>
+
+        <div ref="editor" class="vsc-editor">
+          <div class="vsc-tabs">
+            <span class="tab"><span class="ts">TS</span>{{ fileLabel }}<span class="tab-dot" /></span>
+            <span class="tab dim"><span class="ts dim">TS</span>schema.ts</span>
+          </div>
+          <div class="breadcrumb"><span>src</span><i>›</i><span>db</span><i>›</i><span class="bc-file">{{ fileLabel }}</span></div>
+
+          <div ref="code" class="vsc-code">
+            <div class="gutter" aria-hidden="true"><span v-for="n in lineCount" :key="n">{{ n }}</span></div>
+            <CodeMorph :code="srcCode" :split-tokens="!compact" @ready="onMorphReady" />
+          </div>
+
+          <div class="vsc-status">
+            <span class="st-l">
+              <span class="st-item"><svg viewBox="0 0 16 16" width="12" height="12"><path d="M13 7l-5-5-5 5M8 2v9" /></svg>main</span>
+              <span class="st-item"><span ref="errDot" class="st-err"><svg viewBox="0 0 16 16" width="12" height="12"><circle cx="8" cy="8" r="6.4" fill="none" stroke="currentColor" stroke-width="1.4" /><path d="M8 4.6v4M8 10.7v.1" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" /></svg> <span ref="errCount">0</span></span><span class="st-warn"><svg viewBox="0 0 16 16" width="12" height="12"><path d="M8 2.2l6 11H2z" /><path d="M8 6.6v3M8 11.4v.1" /></svg> 0</span></span>
+            </span>
+            <span class="st-r">SafeQL</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div ref="hover" class="hover" aria-hidden="true" />
+    <div ref="squig" class="squig" aria-hidden="true" />
+    <svg ref="cursor" class="cursor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M5 3l14 7-6 1.6L9.6 17z" fill="#f2f2f4" stroke="#0a0a0b" stroke-width="1.1" stroke-linejoin="round" />
+    </svg>
+
+    <div v-if="auto" class="stepper">
+      <button v-for="(ci, k) in cycle" :key="k" class="stp" :class="{ on: k === autoStep }" type="button" @click="jumpAuto(k)">
+        <span class="stp-track"><span class="stp-fill" :style="{ transform: `scaleX(${k === autoStep ? autoProg : 0})` }" /></span>
+        <span class="stp-label">{{ SCENES[ci].label }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.demo {
+  --bg: #161618;
+  --chrome: #121214;
+  --border: #2a2a2d;
+  --txt: #c7c7cc;
+  --num: #46464d;
+  --err: #d9706f;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative; /* positioning context for the overflowing hover/cursor/squiggle overlays */
+}
+
+.vsc {
+  position: relative;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg);
+  box-shadow: 0 24px 70px -40px rgba(0, 0, 0, 0.9);
+  font-family: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  color: var(--txt);
+  text-align: left;
+}
+.vsc.compact .vsc-act,
+.vsc.compact .vsc-tabs,
+.vsc.compact .breadcrumb,
+.vsc.compact .vsc-status { display: none; }
+
+.vsc-title { display: flex; align-items: center; height: 36px; padding: 0 13px; background: var(--chrome); border-bottom: 1px solid var(--border); }
+.lights { display: flex; gap: 7px; }
+.lights i { width: 11px; height: 11px; border-radius: 50%; background: #34343a; }
+.vsc-name { flex: 1; text-align: center; font-size: 12px; color: #6a6a72; }
+.lights-spacer { width: 47px; }
+
+.vsc-main { display: flex; }
+.vsc-act { width: 44px; flex-shrink: 0; background: var(--chrome); border-right: 1px solid var(--border); display: flex; flex-direction: column; align-items: center; gap: 20px; padding: 14px 0; }
+.vsc-act svg { width: 21px; height: 21px; fill: #44444c; }
+.vsc-act svg.on { fill: #d4d4d8; }
+
+.vsc-editor { position: relative; flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.vsc-tabs { display: flex; background: var(--chrome); border-bottom: 1px solid var(--border); }
+.tab { display: flex; align-items: center; gap: 8px; padding: 9px 16px; font-size: 12.5px; color: #c7c7cc; background: var(--bg); border-top: 1.5px solid #6a7da0; border-right: 1px solid var(--border); }
+.tab.dim { color: #5e5e66; background: var(--chrome); border-top: 1.5px solid transparent; }
+.tab .ts { font-size: 9.5px; font-weight: 600; color: #6a7da0; }
+.tab .ts.dim { color: #44444c; }
+.tab-dot { width: 7px; height: 7px; border-radius: 50%; background: #6a6a72; margin-left: 2px; }
+.breadcrumb { display: flex; align-items: center; gap: 7px; padding: 6px 18px; font-size: 11.5px; color: #54545c; border-bottom: 1px solid var(--border); }
+.breadcrumb i { font-style: normal; color: #3a3a40; }
+.breadcrumb .bc-file { color: #6a6a72; }
+
+.vsc-code { position: relative; padding: 16px 16px 20px; min-height: 240px; box-sizing: border-box; font-size: 13.5px; line-height: 1.95; flex: 1; overflow-x: auto; overflow-y: hidden; display: flex; align-items: flex-start; }
+.gutter {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-width: 1.4em;
+  margin-right: 18px;
+  text-align: right;
+  color: var(--num);
+  user-select: none;
+  font-family: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+.vsc-code :deep(.shiki-magic-move-container) {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0; /* drop the <pre> UA 1em margin so it aligns with the gutter */
+  font-family: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  white-space: pre;
+  background: transparent !important;
+}
+.vsc-code :deep(.shiki-magic-move-item) { background: transparent !important; }
+
+.squig {
+  position: absolute;
+  z-index: 4;
+  height: 5px;
+  background: var(--err);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='8'%20height='5'%3E%3Cpath%20d='M0%204%20Q2%201%204%204%20T8%204'%20stroke='black'%20fill='none'%20stroke-width='1.4'/%3E%3C/svg%3E") repeat-x;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='8'%20height='5'%3E%3Cpath%20d='M0%204%20Q2%201%204%204%20T8%204'%20stroke='black'%20fill='none'%20stroke-width='1.4'/%3E%3C/svg%3E") repeat-x;
+  -webkit-mask-size: 8px 5px;
+  mask-size: 8px 5px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.hover {
+  position: absolute;
+  z-index: 5;
+  width: max-content;
+  max-width: 420px;
+  --pop-bg: #202022;
+  --pop-bd: #3a3a40;
+  background: var(--pop-bg);
+  border: 1px solid var(--pop-bd);
+  border-radius: 5px;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.6);
+  font-size: 12.5px;
+  line-height: 1.55;
+  opacity: 0;
+}
+.hover.info::before {
+  content: "";
+  position: absolute;
+  left: 22px;
+  width: 9px;
+  height: 9px;
+  background: var(--pop-bg);
+  transform: rotate(45deg);
+}
+.hover.info.below::before {
+  top: -5px;
+  border-left: 1px solid var(--pop-bd);
+  border-top: 1px solid var(--pop-bd);
+}
+.hover.info.above::before {
+  bottom: -5px;
+  border-right: 1px solid var(--pop-bd);
+  border-bottom: 1px solid var(--pop-bd);
+}
+.hover :deep(.hv-top) { padding: 9px 13px; color: #d4d4d8; }
+.hover :deep(.hv-msg b) { color: #ededf0; font-weight: 600; }
+.hover :deep(.hv-rule) { color: #74747e; font-family: "Geist Mono", monospace; font-size: 11.5px; }
+.hover :deep(.hv-rule a) { color: #7e93b4; text-decoration: underline; text-underline-offset: 2px; }
+.hover :deep(.hv-actions) { display: flex; gap: 18px; padding: 7px 13px; border-top: 1px solid #303034; background: #1b1b1d; border-radius: 0 0 5px 5px; }
+.hover :deep(.hv-act) { color: #7e93b4; font-size: 12px; }
+.hover :deep(.hv-act kbd) { color: #6a6a72; font-family: "Geist Mono", monospace; font-size: 11px; margin-left: 4px; }
+.hover.info { max-width: 320px; --pop-bg: #1b1f2b; --pop-bd: #36405a; }
+.hover :deep(.hv-info) { display: flex; align-items: flex-start; gap: 9px; padding: 10px 13px; color: #c4ccdc; font-family: "Geist", system-ui, sans-serif; line-height: 1.5; }
+.hover :deep(.hv-info b) { color: #ededf0; font-weight: 600; }
+.hover :deep(.hv-ic) { color: #8aa6d4; flex-shrink: 0; margin-top: 1px; }
+
+.cursor { position: absolute; z-index: 6; width: 20px; height: 20px; left: 0; top: 0; opacity: 0; pointer-events: none; filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.5)); }
+
+.vsc-status { display: flex; align-items: center; justify-content: space-between; height: 24px; padding: 0 12px; background: var(--chrome); border-top: 1px solid var(--border); font-size: 11.5px; color: #6a6a72; }
+.st-l { display: inline-flex; align-items: center; gap: 16px; }
+.st-item { display: inline-flex; align-items: center; gap: 5px; }
+.st-item svg { fill: none; stroke: currentColor; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; }
+.st-err { display: inline-flex; align-items: center; gap: 4px; color: #4b4b52; transition: color 0.4s ease; }
+.st-warn { display: inline-flex; align-items: center; gap: 4px; color: #4b4b52; }
+
+.stepper { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.stp { appearance: none; background: none; border: 0; padding: 0; cursor: pointer; text-align: left; display: flex; flex-direction: column; gap: 9px; font-family: var(--vp-font-family-base, "Geist", system-ui, sans-serif); }
+.stp-track { height: 2px; background: #2a2a2d; border-radius: 2px; overflow: hidden; }
+.stp-fill { display: block; height: 100%; background: #9aa3b4; transform-origin: left; transform: scaleX(0); }
+.stp-label { font-family: var(--vp-font-family-mono, "Geist Mono", ui-monospace, monospace); font-size: 12px; letter-spacing: -0.01em; color: #5e5e66; transition: color 0.3s ease; }
+.stp.on .stp-label,
+.stp:hover .stp-label { color: #d4d4d8; }
+
+@media (max-width: 520px) {
+  .vsc-code { font-size: 10.5px; padding: 12px 12px 14px; }
+  .vsc-code :deep(.shiki-magic-move-line-number) { margin-right: 12px; }
+  .hover { max-width: 250px; }
+  .stp-label { font-size: 11px; }
+}
+
+html:not(.dark) .demo {
+  --bg: #ffffff;
+  --chrome: #f3f3f4;
+  --border: #e4e4e8;
+  --txt: #1f2328;
+  --num: #b6b6bc;
+  --err: #cf222e;
+}
+html:not(.dark) .vsc { box-shadow: 0 16px 50px -30px rgba(0, 0, 0, 0.28); }
+html:not(.dark) .lights i { background: #dcdce0; }
+html:not(.dark) .vsc-name { color: #8a8a92; }
+html:not(.dark) .vsc-act svg { fill: #b6b6bc; }
+html:not(.dark) .vsc-act svg.on { fill: #3a3a40; }
+html:not(.dark) .tab { color: #1f2328; }
+html:not(.dark) .tab.dim { color: #8a8a92; }
+html:not(.dark) .tab .ts.dim { color: #b6b6bc; }
+html:not(.dark) .tab-dot { background: #9a9aa0; }
+html:not(.dark) .breadcrumb { color: #8a8a92; }
+html:not(.dark) .breadcrumb i { color: #c4c4c8; }
+html:not(.dark) .breadcrumb .bc-file { color: #57606a; }
+html:not(.dark) .vsc-status { color: #8a8a92; }
+html:not(.dark) .st-err,
+html:not(.dark) .st-warn { color: #b0b0b6; }
+
+html:not(.dark) .hover { --pop-bg: #ffffff; --pop-bd: #d7d7db; }
+html:not(.dark) .hover :deep(.hv-top) { color: #24292f; }
+html:not(.dark) .hover :deep(.hv-msg b) { color: #1f2328; }
+html:not(.dark) .hover :deep(.hv-rule) { color: #8a8a92; }
+html:not(.dark) .hover :deep(.hv-rule a),
+html:not(.dark) .hover :deep(.hv-act) { color: #4a6da0; }
+html:not(.dark) .hover :deep(.hv-actions) { border-top-color: #e4e4e8; background: #f6f6f7; }
+html:not(.dark) .hover :deep(.hv-act kbd) { color: #8a8a92; }
+html:not(.dark) .hover.info { --pop-bg: #eef2fb; --pop-bd: #c2cee6; }
+html:not(.dark) .hover :deep(.hv-info) { color: #2a3344; }
+html:not(.dark) .hover :deep(.hv-info b) { color: #1f2328; }
+html:not(.dark) .hover :deep(.hv-ic) { color: #4a6da0; }
+
+html:not(.dark) .cursor path { fill: #1f1f1f; stroke: #ffffff; }
+
+html:not(.dark) .stp-track { background: #e4e4e8; }
+html:not(.dark) .stp-label { color: #8a8a92; }
+html:not(.dark) .stp.on .stp-label,
+html:not(.dark) .stp:hover .stp-label { color: #24292f; }
+</style>

--- a/docs/.vitepress/theme/components/landing/HeroCanvas.vue
+++ b/docs/.vitepress/theme/components/landing/HeroCanvas.vue
@@ -1,0 +1,182 @@
+<script setup>
+import { onMounted, onBeforeUnmount, ref, watch } from "vue";
+import { useData } from "vitepress";
+
+const host = ref(null);
+const { isDark } = useData();
+let cleanup = () => {};
+
+onMounted(() => {
+  if (typeof window === "undefined" || !host.value) return;
+  const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  let dark = isDark.value;
+  const stopDark = watch(isDark, (v) => {
+    dark = v;
+    if (prefersReduced) draw();
+  });
+
+  const el = host.value;
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  el.appendChild(canvas);
+  Object.assign(canvas.style, { width: "100%", height: "100%", display: "block" });
+
+  let W = 0, H = 0;
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let dots = [];
+  const circles = [
+    { cx: 0.33, cy: 0.42, rx: 0.22, ry: 0.3, rr: 0.34, omega: 0.5, theta: 0, r: 0, x: 0, y: 0 },
+    { cx: 0.56, cy: 0.58, rx: 0.27, ry: 0.3, rr: 0.3, omega: 0.41, theta: 2.3, r: 0, x: 0, y: 0 },
+  ];
+  let last = 0;
+  let tw = 0;
+  const FOLLOW = 0.28;
+  const DRIFT = 45;
+  let mx = 0, my = 0, offX = 0, offY = 0, hasMouse = false;
+
+  function build() {
+    dots = [];
+    const gap = W < 760 ? 24 : 20;
+    for (let y = gap / 2; y < H; y += gap) {
+      for (let x = gap / 2; x < W; x += gap) {
+        const h1 = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+        const h2 = Math.sin(x * 39.346 + y * 11.135) * 24634.6345;
+        const z = 0.2 + 0.8 * (h1 - Math.floor(h1));
+        dots.push({ x, y, z, ph: (h2 - Math.floor(h2)) * Math.PI * 2, amp: 0.25 + 0.6 * z });
+      }
+    }
+    const m = Math.min(W, H);
+    for (const c of circles) {
+      c.r = Math.max(150, m * c.rr);
+      c.x = W * c.cx + W * c.rx * Math.cos(c.theta) + offX;
+      c.y = H * c.cy + H * c.ry * Math.sin(c.theta) + offY;
+    }
+  }
+
+  function resize() {
+    W = el.clientWidth || window.innerWidth;
+    H = el.clientHeight || window.innerHeight;
+    canvas.width = W * dpr;
+    canvas.height = H * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    build();
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, W, H);
+    const rgb = dark ? "255,255,255" : "0,0,0";
+
+    for (const c of circles) {
+      const g = ctx.createRadialGradient(c.x, c.y, 0, c.x, c.y, c.r);
+      g.addColorStop(0, `rgba(${rgb},${dark ? 0.05 : 0.045})`);
+      g.addColorStop(1, `rgba(${rgb},0)`);
+      ctx.fillStyle = g;
+      ctx.beginPath();
+      ctx.arc(c.x, c.y, c.r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    for (const d of dots) {
+      let fmax = 0, pullx = 0, pully = 0;
+      for (const c of circles) {
+        const dx = c.x - d.x;
+        const dy = c.y - d.y;
+        let f = Math.max(0, 1 - Math.hypot(dx, dy) / c.r);
+        f = f * f * (3 - 2 * f); // smoothstep
+        if (f > fmax) fmax = f;
+        pullx += dx * f * 0.06;
+        pully += dy * f * 0.06;
+      }
+
+      const wob = (1 - fmax) * d.amp;
+      const px = d.x + Math.sin(tw * 2.6 + d.ph) * wob + pullx;
+      const py = d.y + Math.cos(tw * 2.2 + d.ph) * wob + pully;
+
+      const ds = 0.7 + 0.6 * d.z;
+      const a = (dark ? 0.04 : 0.06) + (dark ? 0.11 : 0.14) * d.z + (dark ? 0.55 : 0.5) * fmax;
+      const r = ds + (1 - ds) * fmax;
+      ctx.beginPath();
+      ctx.fillStyle = `rgba(${rgb},${a})`;
+      ctx.arc(px, py, r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  let raf = 0;
+  let visible = true;
+  function frame(now) {
+    const dt = last ? Math.min((now - last) / 1000, 0.05) : 0;
+    last = now;
+    tw += dt;
+    const tox = hasMouse ? (mx - W * 0.5) * FOLLOW : 0;
+    const toy = hasMouse ? (my - H * 0.5) * FOLLOW : 0;
+    const dox = tox - offX, doy = toy - offY;
+    const dlen = Math.hypot(dox, doy);
+    const step = Math.min(dlen, DRIFT * dt);
+    if (dlen > 0.001) { offX += (dox / dlen) * step; offY += (doy / dlen) * step; }
+    for (const c of circles) {
+      c.theta += dt * c.omega;
+      c.x = W * c.cx + W * c.rx * Math.cos(c.theta) + offX;
+      c.y = H * c.cy + H * c.ry * Math.sin(c.theta) + offY;
+    }
+    draw();
+    if (visible) raf = requestAnimationFrame(frame);
+  }
+
+  const io = new IntersectionObserver(
+    ([entry]) => {
+      visible = entry.isIntersecting;
+      cancelAnimationFrame(raf);
+      if (visible && !prefersReduced) {
+        last = 0;
+        raf = requestAnimationFrame(frame);
+      }
+    },
+    { threshold: 0 }
+  );
+
+  const ro = new ResizeObserver(() => {
+    resize();
+    if (prefersReduced) draw();
+  });
+  ro.observe(el);
+  resize();
+  io.observe(el);
+
+  function onMove(e) {
+    const rect = el.getBoundingClientRect();
+    mx = e.clientX - rect.left;
+    my = e.clientY - rect.top;
+    hasMouse = true;
+  }
+  if (!prefersReduced) window.addEventListener("mousemove", onMove, { passive: true });
+
+  if (prefersReduced) draw();
+  else raf = requestAnimationFrame(frame);
+
+  cleanup = () => {
+    cancelAnimationFrame(raf);
+    io.disconnect();
+    ro.disconnect();
+    stopDark();
+    window.removeEventListener("mousemove", onMove);
+    if (canvas.parentNode) canvas.parentNode.removeChild(canvas);
+  };
+});
+
+onBeforeUnmount(() => cleanup());
+</script>
+
+<template>
+  <div ref="host" class="hero-canvas" aria-hidden="true" />
+</template>
+
+<style scoped>
+.hero-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+</style>

--- a/docs/.vitepress/theme/components/landing/Landing.vue
+++ b/docs/.vitepress/theme/components/landing/Landing.vue
@@ -1,0 +1,608 @@
+<script setup>
+import { onBeforeUnmount, ref } from "vue";
+import { useData, withBase } from "vitepress";
+import HeroCanvas from "./HeroCanvas.vue";
+import EditorDemo from "./EditorDemo.vue";
+
+const { site } = useData();
+
+const libraries = ["Prisma", "Kysely", "node-postgres", "Postgres.js", "Sequelize", "Slonik", "Drizzle", "@vercel/postgres"];
+
+const AGENT_PROMPT = `Set up SafeQL in my project — it's an ESLint plugin that type-checks raw SQL against my real PostgreSQL schema.
+
+1. Install: npm i -D @ts-safeql/eslint-plugin libpg-query
+2. Add to my ESLint flat config:
+   import safeql from "@ts-safeql/eslint-plugin/config";
+   export default [
+     safeql.configs.connections({
+       databaseUrl: process.env.DATABASE_URL,
+       targets: [{ tag: "sql" }],
+     }),
+   ];
+3. Use my existing database connection or migrations folder.
+
+Docs: https://safeql.dev/guide/getting-started`;
+
+const copied = ref(false);
+let copyTimer = null;
+function copyPrompt() {
+  if (typeof navigator === "undefined" || !navigator.clipboard) return;
+  navigator.clipboard.writeText(AGENT_PROMPT).then(() => {
+    copied.value = true;
+    if (copyTimer) clearTimeout(copyTimer);
+    copyTimer = setTimeout(() => (copied.value = false), 2200);
+  });
+}
+
+const howIdx = ref(0);
+const howProgress = ref(0);
+const topFeatures = [
+  {
+    title: "Catches what TypeScript can't",
+    desc: "A wrong GROUP BY, a count that's secretly a bigint — SafeQL runs every query against your real schema and flags the bugs the compiler can't see.",
+  },
+  {
+    title: "Works with any client",
+    desc: "postgres.js, Slonik, Prisma, Kysely, Drizzle and more — SafeQL matches each client's own calls by tag or wrapper.",
+  },
+  {
+    title: "Incrementally adoptable",
+    desc: "Point a typed alias at one query and adopt SafeQL at your own pace — everything else stays untouched, and you can opt out anytime.",
+  },
+  {
+    title: "Extensible",
+    desc: "Compose official plugins — AWS IAM auth, Slonik and more — or write your own connection, helper and migration hooks.",
+  },
+];
+
+const features = [
+  "Catches column typos", "Suggests the right column", "Type-mismatch detection", "Operator type errors",
+  "GROUP BY errors", "Unknown table errors", "Invalid cast detection", "Ambiguous column detection",
+  "Missing type annotations", "Wrong type annotations", "Enum value validation",
+  "Automatic result types", "Nullability inference", "Outer-join nullability", "Nullable aggregates",
+  "count(*) is bigint, not number", "numeric → string (no precision loss)", "timestamptz → Date",
+  "uuid & enum types", "json / jsonb result types", "array element types", "Literal type inference",
+  "Custom Postgres → TS overrides", "Per-column type overrides", "snake_case → camelCase",
+  "Your own casing convention", "null vs undefined vs optional", "Wrap results as {type}[]",
+  "CTEs & recursive queries", "Subqueries", "LATERAL joins", "Window functions",
+  "Aggregates (sum, array_agg)", "json_agg / jsonb_agg", "INSERT/UPDATE/DELETE … RETURNING",
+  "ON CONFLICT upserts", "set-returning functions",
+  "Validate against a live database", "Shadow DB from your migrations", "Watch mode for CI",
+  "Multiple databases", "Monorepo-friendly",
+  "postgres.js", "Slonik", "Prisma", "Kysely", "Drizzle", "node-postgres", "Sequelize", "@vercel/postgres",
+  "Zod schema validation", "Zod schema generation", "SQL fragment composition", "Editor quick-fixes",
+  "Auto-fix with --fix", "Incremental adoption", "Flexible query targeting", "Write your own plugins",
+  "AWS IAM auth for RDS",
+];
+
+const ROWS = 5;
+function isStrong(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h % 100 < 38;
+}
+const featureRows = Array.from({ length: ROWS }, (_, r) =>
+  features.filter((_, i) => i % ROWS === r).map((t) => ({ t, strong: isStrong(t) }))
+);
+
+const howRoot = ref(null);
+let advanceTimer = null;
+const HOLD = 1500;
+
+function onSceneProgress(p) {
+  howProgress.value = p;
+}
+function onSceneDone() {
+  if (advanceTimer) clearTimeout(advanceTimer);
+  advanceTimer = setTimeout(() => {
+    howIdx.value = (howIdx.value + 1) % topFeatures.length;
+  }, HOLD);
+}
+function howSelect(i) {
+  if (advanceTimer) clearTimeout(advanceTimer);
+  howIdx.value = i;
+  howProgress.value = 0;
+}
+
+onBeforeUnmount(() => {
+  if (advanceTimer) clearTimeout(advanceTimer);
+  if (copyTimer) clearTimeout(copyTimer);
+});
+</script>
+
+<template>
+  <div class="landing">
+    <section class="hero" data-hero>
+      <HeroCanvas />
+      <div class="hero-veil" aria-hidden="true" />
+      <div class="hero-grid">
+        <div class="hero-copy">
+          <h1 class="hero-title">Write SQL queries with confidence.</h1>
+          <p class="hero-sub">
+            An ESLint plugin that validates raw SQL against your real PostgreSQL
+            schema and infers result types — before the query ever runs.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" :href="withBase('/guide/getting-started')">Get started</a>
+            <a class="btn btn-ghost" href="https://github.com/ts-safeql/safeql" target="_blank" rel="noreferrer">
+              <svg width="17" height="17" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
+              </svg>
+              GitHub
+            </a>
+          </div>
+          <button class="agent-copy" :class="{ copied }" type="button" @click="copyPrompt">
+            <svg v-if="!copied" width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <rect x="9" y="9" width="11" height="11" rx="2" stroke="currentColor" stroke-width="1.7" />
+              <path d="M5 15V5a2 2 0 012-2h10" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+            </svg>
+            <svg v-else width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M5 12.5l4.5 4.5L19 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            <span>{{ copied ? "Copied — paste into your agent" : "Copy setup prompt for your agent" }}</span>
+          </button>
+        </div>
+        <div class="hero-demo">
+          <EditorDemo auto :cycle="[0, 1, 2]" />
+        </div>
+      </div>
+    </section>
+
+    <section ref="howRoot" class="section how">
+      <div class="how-head">
+        <span class="kicker">Features</span>
+        <h2>See SafeQL work, feature by feature.</h2>
+      </div>
+      <div class="how-grid">
+        <div class="acc">
+          <button
+            v-for="(s, i) in topFeatures"
+            :key="i"
+            class="acc-item"
+            :class="{ on: howIdx === i }"
+            type="button"
+            @click="howSelect(i)"
+          >
+            <span class="acc-prog" :style="{ transform: `scaleX(${howIdx === i ? howProgress : 0})` }" />
+            <span class="acc-title">{{ s.title }}</span>
+            <div class="acc-body"><p>{{ s.desc }}</p></div>
+          </button>
+        </div>
+        <div class="how-ide">
+          <EditorDemo :scene="howIdx + 3" compact @progress="onSceneProgress" @done="onSceneDone" />
+        </div>
+      </div>
+
+      <div class="more">
+        <div class="ticker" aria-hidden="true">
+          <div
+            v-for="(row, ri) in featureRows"
+            :key="ri"
+            class="ticker-row"
+            :class="{ rev: ri % 2 === 1 }"
+            :style="{ '--dur': row.length * 4.5 + 's' }"
+          >
+            <div class="ticker-track">
+              <span v-for="(f, i) in row.concat(row)" :key="i" class="ticker-item" :class="{ strong: f.strong }">{{ f.t }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer class="foot">
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <img :src="withBase('/safeql-logo.svg')" alt="" class="brand-mark" />
+          <span>{{ site.title }}</span>
+        </div>
+        <div class="foot-links">
+          <a :href="withBase('/guide/introduction')">Guide</a>
+          <a :href="withBase('/api/')">API</a>
+          <a href="https://github.com/ts-safeql/safeql" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="https://x.com/CoEliya" target="_blank" rel="noreferrer">X</a>
+        </div>
+        <span class="foot-note">MIT Licensed · Built for PostgreSQL</span>
+      </div>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.landing {
+  --bg: #0a0a0b;
+  --bg-2: #101012;
+  --panel: rgba(255, 255, 255, 0.024);
+  --line: rgba(255, 255, 255, 0.1);
+  --line-soft: rgba(255, 255, 255, 0.06);
+  --line-strong: rgba(255, 255, 255, 0.28);
+  --raise: rgba(255, 255, 255, 0.035);
+  --raise-soft: rgba(255, 255, 255, 0.02);
+  --raise-2: rgba(255, 255, 255, 0.05);
+  --text: #ececed;
+  --muted: #8c8c92;
+  --faint: #5a5a60;
+  --accent: #7c98c0;
+  --ok: #8faa6e;
+  --btn-hover: #ffffff;
+  --r: 4px;
+  /* matches the VitePress nav content column: width: min(100% - 64px, var(--cw)) + margin auto */
+  --cw: calc(var(--vp-layout-max-width, 1440px) - 64px);
+  --font: "Geist", system-ui, -apple-system, sans-serif;
+  --mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  position: relative;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  line-height: 1.6;
+  overflow-x: clip;
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: -0.005em;
+}
+html:not(.dark) .landing {
+  --bg: #ffffff;
+  --bg-2: #f6f6f7;
+  --panel: rgba(0, 0, 0, 0.025);
+  --line: rgba(0, 0, 0, 0.12);
+  --line-soft: rgba(0, 0, 0, 0.07);
+  --line-strong: rgba(0, 0, 0, 0.28);
+  --raise: rgba(0, 0, 0, 0.04);
+  --raise-soft: rgba(0, 0, 0, 0.022);
+  --raise-2: rgba(0, 0, 0, 0.06);
+  --text: #1b1b1f;
+  --muted: #555a63;
+  --faint: #8a8a92;
+  --accent: #4a6da0;
+  --ok: #4d7a2e;
+  --btn-hover: #000000;
+}
+.landing :where(h1, h2, h3) {
+  line-height: 1.08;
+  letter-spacing: -0.022em;
+  font-weight: 540;
+  margin: 0;
+}
+
+.hero {
+  position: relative;
+  min-height: calc(100vh - var(--vp-nav-height, 64px));
+  min-height: calc(100svh - var(--vp-nav-height, 64px));
+  display: grid;
+  place-items: center;
+  padding: 48px 0 72px;
+  overflow: hidden;
+}
+.hero-veil {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(135% 100% at 60% 0%, transparent 58%, var(--bg) 97%);
+  pointer-events: none;
+}
+.hero-grid {
+  position: relative;
+  z-index: 2;
+  width: min(100% - 64px, var(--cw));
+  margin-inline: auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.18fr);
+  gap: clamp(28px, 4.5vw, 60px);
+  align-items: center;
+}
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 22px;
+}
+.hero-demo {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+.hero-title {
+  font-size: clamp(2.1rem, 4vw, 3.4rem);
+  font-weight: 540;
+  letter-spacing: -0.03em;
+  max-width: 13ch;
+}
+.hero-sub {
+  max-width: 480px;
+  font-size: clamp(1rem, 1.3vw, 1.12rem);
+  color: var(--muted);
+  margin: 0;
+}
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 20px;
+  border-radius: var(--r);
+  font-weight: 500;
+  font-size: 14.5px;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+.btn-primary {
+  background: var(--text);
+  color: var(--bg);
+}
+.btn-primary:hover {
+  background: var(--btn-hover);
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--line);
+}
+.btn-ghost:hover {
+  border-color: var(--line-strong);
+}
+.agent-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 13px;
+  transition: color 0.2s ease;
+}
+.agent-copy:hover {
+  color: var(--text);
+}
+.agent-copy.copied {
+  color: var(--ok);
+}
+
+.section {
+  position: relative;
+  z-index: 1;
+  width: min(100% - 64px, var(--cw));
+  margin: 0 auto;
+  padding: clamp(72px, 12vh, 140px) 0;
+}
+.kicker {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin-bottom: 16px;
+}
+.section h2 {
+  font-size: clamp(1.7rem, 3.4vw, 2.4rem);
+}
+.how-head {
+  max-width: 720px;
+}
+
+.how-grid {
+  margin-top: 48px;
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 32px;
+  align-items: start;
+}
+.acc {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.acc-item {
+  position: relative;
+  overflow: hidden;
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 0;
+  border-radius: var(--r);
+  padding: 16px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.25s ease;
+}
+.acc-item.on {
+  background: var(--raise);
+}
+.acc-item:not(.on):hover {
+  background: var(--raise-soft);
+}
+.acc-item:not(.on):hover .acc-title {
+  color: var(--text);
+}
+/* doubles as the scene progress bar (scaleX driven by howProgress) */
+.acc-prog {
+  position: absolute;
+  inset: 0;
+  background: var(--raise-2);
+  transform-origin: left;
+  transform: scaleX(0);
+  pointer-events: none;
+  border-radius: inherit;
+}
+.acc-title,
+.acc-body {
+  position: relative;
+  z-index: 1;
+}
+.acc-title {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 540;
+  color: var(--muted);
+  transition: color 0.25s ease;
+}
+.acc-item.on .acc-title {
+  color: var(--text);
+}
+.acc-body {
+  /* animate 0fr ↔ 1fr (not height) so expand/collapse causes no layout shift on turns */
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 0.35s ease, opacity 0.35s ease, padding-top 0.35s ease;
+}
+.acc-item.on .acc-body {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  padding-top: 8px;
+}
+.acc-body p {
+  margin: 0;
+  min-height: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+.how-ide {
+  min-width: 0;
+}
+
+.more {
+  margin-top: 64px;
+}
+.ticker {
+  /* full-bleed: span the viewport, escaping the container width */
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  opacity: 0.25;
+  pointer-events: none;
+}
+.ticker-row {
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 6%, #000 94%, transparent);
+  mask-image: linear-gradient(to right, transparent, #000 6%, #000 94%, transparent);
+}
+.ticker-track {
+  display: inline-flex;
+  white-space: nowrap;
+  will-change: transform;
+  animation: ticker-move var(--dur, 60s) linear infinite;
+}
+.ticker-row.rev .ticker-track {
+  animation-direction: reverse;
+}
+@keyframes ticker-move {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.ticker-item {
+  padding-right: 1.7em;
+  font-size: 20px;
+  color: var(--faint);
+}
+.ticker-item.strong {
+  color: var(--text);
+  font-weight: 540;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ticker-track { animation: none; }
+}
+.clients {
+  margin-top: 44px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 24px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--faint);
+}
+.client { white-space: nowrap; }
+
+.foot {
+  border-top: 1px solid var(--line-soft);
+  padding: 36px 0;
+  background: var(--bg);
+}
+.foot-inner {
+  width: min(100% - 64px, var(--cw));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.foot-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 540;
+}
+.foot-brand .brand-mark {
+  width: 18px;
+  height: 23px;
+}
+.foot-links {
+  display: flex;
+  gap: 22px;
+}
+.foot-links a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 14px;
+}
+.foot-links a:hover {
+  color: var(--text);
+}
+.foot-note {
+  color: var(--faint);
+  font-size: 13px;
+}
+
+@media (max-width: 980px) {
+  .hero {
+    min-height: auto;
+    place-items: start center;
+    padding-top: 96px;
+  }
+  .hero-grid {
+    grid-template-columns: 1fr;
+    gap: 36px;
+    max-width: 620px;
+  }
+  .hero-copy {
+    align-items: center;
+    text-align: center;
+  }
+  .hero-title {
+    max-width: none;
+  }
+  .hero-sub {
+    margin-inline: auto;
+  }
+  .hero-actions {
+    justify-content: center;
+  }
+}
+@media (max-width: 860px) {
+  .how-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+@media (max-width: 600px) {
+  .topnav a:not(.nav-cta) {
+    display: none;
+  }
+  .topnav a:nth-last-child(2) {
+    display: inline;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/landing/highlighter.js
+++ b/docs/.vitepress/theme/components/landing/highlighter.js
@@ -1,0 +1,52 @@
+import { createHighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import ts from "shiki/langs/typescript.mjs";
+
+const safeqlTheme = {
+  name: "safeql-dark",
+  type: "dark",
+  colors: { "editor.background": "#161618", "editor.foreground": "#c7c7cc" },
+  settings: [
+    { settings: { background: "#161618", foreground: "#c7c7cc" } },
+    { scope: ["comment", "punctuation.definition.comment"], settings: { foreground: "#5e5e66", fontStyle: "italic" } },
+    { scope: ["keyword", "storage.type", "storage.modifier", "keyword.control", "keyword.operator.new", "keyword.operator.expression"], settings: { foreground: "#8aa0c8" } },
+    { scope: ["string", "string.template", "punctuation.definition.string", "string.quoted"], settings: { foreground: "#98aa82" } },
+    { scope: ["entity.name.function", "support.function", "meta.function-call", "variable.function"], settings: { foreground: "#8aa0c8" } },
+    { scope: ["entity.name.type", "support.type", "entity.name.class", "support.class", "entity.other.inherited-class"], settings: { foreground: "#6cb3c4" } },
+    { scope: ["constant.numeric", "constant.language", "constant.language.boolean"], settings: { foreground: "#d9a05b" } },
+    { scope: ["punctuation", "meta.brace", "punctuation.accessor", "punctuation.separator"], settings: { foreground: "#5e5e66" } },
+    { scope: ["variable.other.property", "meta.object-literal.key", "support.type.property-name", "variable.object.property"], settings: { foreground: "#9cc0e8" } },
+    { scope: ["variable", "variable.other", "meta.definition.variable"], settings: { foreground: "#c7c7cc" } },
+  ],
+};
+
+const safeqlLightTheme = {
+  name: "safeql-light",
+  type: "light",
+  colors: { "editor.background": "#ffffff", "editor.foreground": "#1f2328" },
+  settings: [
+    { settings: { background: "#ffffff", foreground: "#1f2328" } },
+    { scope: ["comment", "punctuation.definition.comment"], settings: { foreground: "#6a737d", fontStyle: "italic" } },
+    { scope: ["keyword", "storage.type", "storage.modifier", "keyword.control", "keyword.operator.new", "keyword.operator.expression"], settings: { foreground: "#3b5b92" } },
+    { scope: ["string", "string.template", "punctuation.definition.string", "string.quoted"], settings: { foreground: "#557a35" } },
+    { scope: ["entity.name.function", "support.function", "meta.function-call", "variable.function"], settings: { foreground: "#3b5b92" } },
+    { scope: ["entity.name.type", "support.type", "entity.name.class", "support.class", "entity.other.inherited-class"], settings: { foreground: "#1f7a8c" } },
+    { scope: ["constant.numeric", "constant.language", "constant.language.boolean"], settings: { foreground: "#b06a2a" } },
+    { scope: ["punctuation", "meta.brace", "punctuation.accessor", "punctuation.separator"], settings: { foreground: "#8a8a90" } },
+    { scope: ["variable.other.property", "meta.object-literal.key", "support.type.property-name", "variable.object.property"], settings: { foreground: "#3b6ea5" } },
+    { scope: ["variable", "variable.other", "meta.definition.variable"], settings: { foreground: "#1f2328" } },
+  ],
+};
+
+let promise = null;
+
+export function getHighlighter() {
+  if (!promise) {
+    promise = createHighlighterCore({
+      themes: [safeqlTheme, safeqlLightTheme],
+      langs: [ts],
+      engine: createJavaScriptRegexEngine(),
+    });
+  }
+  return promise;
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,17 +1,81 @@
+/* =====================================================================
+   SafeQL docs theme — aligned with the landing page's design language.
+   (Landing is the source of truth: near-black surfaces, Geist + Geist Mono,
+   a restrained steel-blue accent, subtle white-alpha lines, sharp 4px corners.)
+   Docs are forced dark (config: appearance: 'force-dark') to match.
+   ===================================================================== */
+
+:root {
+  --vp-font-family-base: "Geist", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --vp-font-family-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+}
+
+.dark {
+  /* surfaces — match the landing's --bg / panels */
+  --vp-c-bg: #0a0a0b;
+  --vp-c-bg-alt: #0e0e10;
+  --vp-c-bg-soft: #141416;
+  --vp-c-bg-elv: #161618;
+
+  /* text — landing --text / --muted / --faint */
+  --vp-c-text-1: #ececed;
+  --vp-c-text-2: #9a9aa1;
+  --vp-c-text-3: #66666d;
+
+  /* lines — subtle white-alpha, like the landing */
+  --vp-c-border: rgba(255, 255, 255, 0.12);
+  --vp-c-divider: rgba(255, 255, 255, 0.07);
+  --vp-c-gutter: #0a0a0b;
+  --vp-c-default-soft: rgba(255, 255, 255, 0.05);
+
+  /* brand — the landing's steel-blue accent */
+  --vp-c-brand-1: #9bb2d6;
+  --vp-c-brand-2: #b6c7e4;
+  --vp-c-brand-3: #6e88b0;
+  --vp-c-brand-soft: rgba(124, 152, 192, 0.14);
+
+  /* code surface — match the IDE on the landing */
+  --vp-code-block-bg: #131316;
+  --vp-code-bg: rgba(255, 255, 255, 0.06);
+
+  /* primary buttons read light-on-dark like the landing's CTA */
+  --vp-button-brand-border: transparent;
+  --vp-button-brand-text: #0a0a0b;
+  --vp-button-brand-bg: #ececed;
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-hover-text: #0a0a0b;
+  --vp-button-brand-hover-bg: #ffffff;
+  --vp-button-brand-active-border: transparent;
+  --vp-button-brand-active-text: #0a0a0b;
+  --vp-button-brand-active-bg: #d4d4d8;
+}
+
+/* sharp corners to match the landing (--r: 4px) instead of VitePress' pills/8px */
+.VPButton {
+  border-radius: 4px;
+}
+.vp-doc div[class*="language-"],
+.vp-doc .vp-code-group,
+.vp-doc .custom-block,
+.VPNavScreenMenuGroup,
+.DocSearch-Button {
+  border-radius: 4px;
+}
+
+/* ===== existing code-line highlight helpers ===== */
 .line.highlighted.error {
   --vp-code-line-highlight-color: var(--vp-c-red-dimm-2);
 }
 
 .line.highlighted.error span {
-    --shiki-light: var(--vp-c-danger-1) !important;
-    --shiki-dark: var(--vp-c-danger-1) !important;
+  --shiki-light: var(--vp-c-danger-1) !important;
+  --shiki-dark: var(--vp-c-danger-1) !important;
 }
-
 
 .success .line.highlighted {
   --vp-code-line-highlight-color: var(--vp-c-green-soft) !important;
 }
 
 .success .line.highlighted span {
-    color: var(--vp-c-green-1) !important;
+  color: var(--vp-c-green-1) !important;
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import { enhanceAppWithTabs } from "vitepress-plugin-tabs/client";
 import Theme from "vitepress/theme";
 import Layout from "./Layout.vue";
+import Landing from "./components/landing/Landing.vue";
 import "./custom.css";
 
 export default {
@@ -8,6 +9,7 @@ export default {
   Layout: Layout,
   async enhanceApp({ app }) {
     enhanceAppWithTabs(app);
+    app.component("Landing", Landing);
 
     import("@vercel/analytics").then(({ default: analytics }) => {
       analytics.inject();

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,34 +1,9 @@
 ---
-layout: home
-
-hero:
-  name: SafeQL
-  text: Write SQL Queries With Confidence
-  tagline: |
-    An ESLint plugin for writing SQL queries
-    in a type-safe way.
-  image:
-    src: /ts-pg-logo.svg
-    alt: ts-safeql
-  actions:
-    - theme: brand
-      text: Get Started
-      link: /guide/introduction
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/ts-safeql/safeql
-
-features:
-  - icon: ⚡️
-    title: Automatic Type Inference & Validation
-    details: SafeQL automatically infers the type of the query result based on the query itself.
-  - icon: 🖖
-    title: Compatible With Popular SQL Libraries
-    details: SafeQL works with any PostgreSQL client, including Prisma, Sequelize, pg, Postgres.js, and more.
-  - icon: 🛠️
-    title: Easy To Use
-    details: SafeQL was built in mind to be easy to use and integrate with your existing codebase.
-  - icon: 📦
-    title: Built with Monorepos & Microservices in mind
-    details: SafeQL was built with monorepos and microservices in mind, and it's easy to use with multiple databases.
+layout: page
+sidebar: false
+aside: false
+title: SafeQL — Write SQL queries with confidence
+description: An ESLint plugin that validates and auto-generates TypeScript types from raw SQL queries in PostgreSQL.
 ---
+
+<Landing />

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,9 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "gsap": "^3.15.0",
+    "shiki": "^2.5.0",
+    "shiki-magic-move": "^1.4.0",
     "vitepress": "^1.6.3",
     "vitepress-plugin-tabs": "^0.6.0",
     "vue": "^3.5.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,15 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0(vue@3.5.13(typescript@5.8.2))
     devDependencies:
+      gsap:
+        specifier: ^3.15.0
+        version: 3.15.0
+      shiki:
+        specifier: ^2.5.0
+        version: 2.5.0
+      shiki-magic-move:
+        specifier: ^1.4.0
+        version: 1.4.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2))
       vitepress:
         specifier: ^1.6.3
         version: 1.6.3(@algolia/client-search@5.22.0)(@types/node@24.12.0)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.2)
@@ -2162,6 +2171,27 @@ packages:
   '@shikijs/langs@2.5.0':
     resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
 
+  '@shikijs/magic-move@4.2.0':
+    resolution: {integrity: sha512-KJBoKtpl04+ee6umjgt/qBveQPkCt+cMfaWJWbrRqqBtMCY8q0kufMPSjzJwLhNuSs2c0/D3BteOCOFAwg28rg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      shiki: ^4.0.0
+      solid-js: ^1.9.1
+      svelte: ^5.0.0-0
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      shiki:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
   '@shikijs/themes@2.5.0':
     resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
 
@@ -2976,6 +3006,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff-match-patch-es@1.0.1:
+    resolution: {integrity: sha512-KhSofrZDERg/NE6Nd+TK53knp2qz0o2Ix8rhkXd3Chfm7Wlo58Eq/juNmkyS6bS+3xS26L3Pstz3BdY/q+e9UQ==}
+
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -3239,6 +3272,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gsap@3.15.0:
+    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -3522,6 +3558,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
@@ -4093,6 +4132,28 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki-magic-move@1.4.0:
+    resolution: {integrity: sha512-DDEv7khyBMAQghQEfQ6Ab3KZxT5ub6tVNe8+NcvglWauKVV9jxiRYC055DoiFLgvs6Hd9+LuBndeaSPNOSxgSg==}
+    engines: {node: '>=20'}
+    deprecated: shiki-magic-move is now @shikijs/magic-move, please migrate by renaming the package
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      shiki: ^4.0.0
+      solid-js: ^1.9.1
+      svelte: ^5.0.0-0
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      shiki:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   shiki@2.5.0:
     resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
@@ -5833,6 +5894,14 @@ snapshots:
     dependencies:
       '@shikijs/types': 2.5.0
 
+  '@shikijs/magic-move@4.2.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2))':
+    dependencies:
+      diff-match-patch-es: 1.0.1
+      ohash: 2.0.11
+    optionalDependencies:
+      shiki: 2.5.0
+      vue: 3.5.13(typescript@5.8.2)
+
   '@shikijs/themes@2.5.0':
     dependencies:
       '@shikijs/types': 2.5.0
@@ -6793,6 +6862,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff-match-patch-es@1.0.1: {}
+
   diff@4.0.2: {}
 
   dir-glob@3.0.1:
@@ -7145,6 +7216,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gsap@3.15.0: {}
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -7401,6 +7474,8 @@ snapshots:
   obuf@1.1.2: {}
 
   obug@2.1.1: {}
+
+  ohash@2.0.11: {}
 
   oniguruma-to-es@3.1.1:
     dependencies:
@@ -7944,6 +8019,13 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki-magic-move@1.4.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2)):
+    dependencies:
+      '@shikijs/magic-move': 4.2.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2))
+    optionalDependencies:
+      shiki: 2.5.0
+      vue: 3.5.13(typescript@5.8.2)
 
   shiki@2.5.0:
     dependencies:


### PR DESCRIPTION
Redesigns the docs landing page: a custom, animated hero IDE (Shiki Magic Move) and a "Features" accordion driving a live demo, replacing the default VitePress hero. Shares its visual language with the docs theme, with full dark/light support and a nav unified with the docs.

Adds `gsap`, `shiki`, and `shiki-magic-move` as docs `devDependencies` (private package — no published impact). `pnpm docs:build` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive animated code editor demo showcasing SafeQL capabilities
  * Enhanced visual animations and canvas effects on the landing page
  * Redesigned homepage with improved presentation

* **Style**
  * Applied dark theme to documentation site
  * Updated branding with new logo and X social link
  * Refreshed visual design with updated color scheme and typography

<!-- end of auto-generated comment: release notes by coderabbit.ai -->