### PR TITLE
fix(docs): landing page follow-ups (review feedback + hero morph)

### DIFF
--- a/docs/.vitepress/theme/components/landing/CodeMorph.vue
+++ b/docs/.vitepress/theme/components/landing/CodeMorph.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { shallowRef, onMounted, computed } from "vue";
 import { useData } from "vitepress";
-import { ShikiMagicMove } from "shiki-magic-move/vue";
-import "shiki-magic-move/style.css";
+import { ShikiMagicMove } from "@shikijs/magic-move/vue";
+import "@shikijs/magic-move/style.css";
 import { getHighlighter } from "./highlighter";
 
 defineProps({

--- a/docs/.vitepress/theme/components/landing/EditorDemo.vue
+++ b/docs/.vitepress/theme/components/landing/EditorDemo.vue
@@ -35,13 +35,16 @@ let gsapReady = false;
 let morphReady = false;
 let started = false;
 let autoPos = 0;
+// cross-fade the next scene entry instead of morphing — used for the auto loop
+// wrap and stepper jumps, where a morph would run the code backwards
+let fadeNext = false;
 
 const H0_A = "function getUsers() {\n  return sql`\n    SELECT idd FROM users\n  `;\n}";
 const H0_B = "function getUsers() {\n  return sql`\n    SELECT id FROM users\n  `;\n}";
-const H1_A = "function getUsers() {\n  return sql`\n    SELECT id, email FROM users\n  `;\n}";
-const H1_B = "function getUsers() {\n  return sql<{ id: number; email: string }>`\n    SELECT id, email FROM users\n  `;\n}";
-const H2_A = "function getUsers() {\n  return sql<{ id: string }>`\n    SELECT id FROM users\n  `;\n}";
-const H2_B = "function getUsers() {\n  return sql<{ id: number }>`\n    SELECT id FROM users\n  `;\n}";
+const H1_A = "function getUsers() {\n  return sql`\n    SELECT id FROM users\n  `;\n}";
+const H1_B = "function getUsers() {\n  return sql<{ id: number }>`\n    SELECT id FROM users\n  `;\n}";
+const H2_A = "function getUsers() {\n  return sql<{ id: number; email: number }>`\n    SELECT id, email FROM users\n  `;\n}";
+const H2_B = "function getUsers() {\n  return sql<{ id: number; email: string }>`\n    SELECT id, email FROM users\n  `;\n}";
 
 const A1_A = "function postStats() {\n  return sql<{ author_id: number; posts: number }>`\n    SELECT author_id, count(*) AS posts\n    FROM posts\n    GROUP BY status\n  `;\n}";
 const A1_B = "function postStats() {\n  return sql<{ author_id: number; posts: number }>`\n    SELECT author_id, count(*) AS posts\n    FROM posts\n    GROUP BY author_id\n  `;\n}";
@@ -79,7 +82,7 @@ const SCENES = [
     label: "Auto-fixes types",
     file: "users.ts",
     code: H2_A,
-    acts: [{ t: "error", find: ["string", 1], msg: "incorrect type annotation — expected <b>number</b>", hold: 2.4, fix: H2_B, clear: true }],
+    acts: [{ t: "error", find: ["number", 2], msg: "incorrect type for <b>email</b> — expected <b>string</b>", hold: 2.4, fix: H2_B, clear: true }],
   },
   {
     file: "stats.ts",
@@ -282,7 +285,9 @@ function buildScene(i, gsap) {
   setErr(0);
   const enter = () => { srcCode.value = s.code; fileLabel.value = s.file; setErr(0); };
   const t = gsap.timeline({ defaults: { ease: "power2.out" } });
-  if (started && !props.auto) {
+  const fade = (started && !props.auto) || fadeNext;
+  fadeNext = false;
+  if (fade) {
     t.to(code.value, { opacity: 0, duration: 0.3 })
       .add(enter)
       .to({}, { duration: 0.72 })
@@ -323,6 +328,7 @@ function play() {
     if (!visible) return;
     if (props.auto) {
       autoPos++;
+      if (autoPos % props.cycle.length === 0) fadeNext = true;
       gap = gsapRef.delayedCall(0.12, play);
     } else {
       emit("done");
@@ -337,6 +343,7 @@ function restart() {
 }
 function jumpAuto(k) {
   if (!props.auto) return;
+  fadeNext = true;
   autoPos = k;
   restart();
 }

--- a/docs/.vitepress/theme/components/landing/Landing.vue
+++ b/docs/.vitepress/theme/components/landing/Landing.vue
@@ -6,7 +6,6 @@ import EditorDemo from "./EditorDemo.vue";
 
 const { site } = useData();
 
-const libraries = ["Prisma", "Kysely", "node-postgres", "Postgres.js", "Sequelize", "Slonik", "Drizzle", "@vercel/postgres"];
 
 const AGENT_PROMPT = `Set up SafeQL in my project — it's an ESLint plugin that type-checks raw SQL against my real PostgreSQL schema.
 
@@ -514,17 +513,6 @@ html:not(.dark) .landing {
 @media (prefers-reduced-motion: reduce) {
   .ticker-track { animation: none; }
 }
-.clients {
-  margin-top: 44px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 24px;
-  font-family: var(--mono);
-  font-size: 13px;
-  color: var(--faint);
-}
-.client { white-space: nowrap; }
-
 .foot {
   border-top: 1px solid var(--line-soft);
   padding: 36px 0;
@@ -595,14 +583,6 @@ html:not(.dark) .landing {
   .how-grid {
     grid-template-columns: 1fr;
     gap: 24px;
-  }
-}
-@media (max-width: 600px) {
-  .topnav a:not(.nav-cta) {
-    display: none;
-  }
-  .topnav a:nth-last-child(2) {
-    display: inline;
   }
 }
 </style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -2,7 +2,7 @@
    SafeQL docs theme — aligned with the landing page's design language.
    (Landing is the source of truth: near-black surfaces, Geist + Geist Mono,
    a restrained steel-blue accent, subtle white-alpha lines, sharp 4px corners.)
-   Docs are forced dark (config: appearance: 'force-dark') to match.
+   Docs default to dark to match (config: appearance: 'dark'); the nav toggle still allows light.
    ===================================================================== */
 
 :root {

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,9 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@shikijs/magic-move": "^4.2.0",
     "gsap": "^3.15.0",
     "shiki": "^2.5.0",
-    "shiki-magic-move": "^1.4.0",
     "vitepress": "^1.6.3",
     "vitepress-plugin-tabs": "^0.6.0",
     "vue": "^3.5.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,15 +611,15 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0(vue@3.5.13(typescript@5.8.2))
     devDependencies:
+      '@shikijs/magic-move':
+        specifier: ^4.2.0
+        version: 4.2.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2))
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
       shiki:
         specifier: ^2.5.0
         version: 2.5.0
-      shiki-magic-move:
-        specifier: ^1.4.0
-        version: 1.4.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2))
       vitepress:
         specifier: ^1.6.3
         version: 1.6.3(@algolia/client-search@5.22.0)(@types/node@24.12.0)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.2)
@@ -4132,28 +4132,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shiki-magic-move@1.4.0:
-    resolution: {integrity: sha512-DDEv7khyBMAQghQEfQ6Ab3KZxT5ub6tVNe8+NcvglWauKVV9jxiRYC055DoiFLgvs6Hd9+LuBndeaSPNOSxgSg==}
-    engines: {node: '>=20'}
-    deprecated: shiki-magic-move is now @shikijs/magic-move, please migrate by renaming the package
-    peerDependencies:
-      react: ^18.2.0 || ^19.0.0
-      shiki: ^4.0.0
-      solid-js: ^1.9.1
-      svelte: ^5.0.0-0
-      vue: ^3.4.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      shiki:
-        optional: true
-      solid-js:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
 
   shiki@2.5.0:
     resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
@@ -8019,13 +7997,6 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shiki-magic-move@1.4.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2)):
-    dependencies:
-      '@shikijs/magic-move': 4.2.0(shiki@2.5.0)(vue@3.5.13(typescript@5.8.2))
-    optionalDependencies:
-      shiki: 2.5.0
-      vue: 3.5.13(typescript@5.8.2)
 
   shiki@2.5.0:
     dependencies:


### PR DESCRIPTION
Follow-ups to #488:

- Fix the hero IDE morph: chain the three scenes into a forward story so morphs only add/fix (no backwards garble), and cross-fade the loop wrap.
- Migrate `shiki-magic-move` → `@shikijs/magic-move` (former is a deprecated shim).
- Remove dead code in `Landing.vue` and fix a stale `custom.css` comment.

`pnpm docs:build` passes.