### PR TITLE
feat(eslint-plugin): plugin-driven rule engine

### DIFF
--- a/packages/connection-manager/src/index.ts
+++ b/packages/connection-manager/src/index.ts
@@ -52,6 +52,12 @@ export function createConnectionManager() {
     ) => {
       return getOrCreateFromPlugins(plugins, connectionMap, pluginManager, projectDir);
     },
+    resolveMigrate: (
+      plugins: Array<{ package: string; config?: Record<string, unknown> }>,
+      projectDir: string,
+    ) => {
+      return pluginManager.resolveMigrate(plugins, projectDir);
+    },
     close: (strategy: ConnectionStrategy) => {
       return closeConnection(strategy, connectionMap, pluginManager);
     },

--- a/packages/eslint-plugin/src/rules/check-sql.config.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.config.ts
@@ -1,12 +1,11 @@
 import { createRequire } from "module";
 import path from "path";
 import { E, pipe } from "../utils/fp-ts";
-import { RuleContext } from "./check-sql.rule";
-import { Config, Options, UserConfigFile, zConfig } from "./RuleOptions";
+import { Config, Options, RuleOptions, UserConfigFile, zConfig } from "./RuleOptions";
 import { InvalidConfigError } from "@ts-safeql/shared";
 
 export function getConfigFromFileWithContext(params: {
-  context: RuleContext;
+  context: { options: RuleOptions };
   projectDir: string;
 }): Config {
   const options = params.context.options[0];

--- a/packages/eslint-plugin/src/rules/check-sql.rule.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.rule.ts
@@ -1,8 +1,11 @@
 import { ResolvedTarget } from "@ts-safeql/generate";
 import {
   PluginManager,
+  matchesQueryNodeSelector,
   type PluginResolvedTarget,
+  type QueryNodeSelector,
   type SafeQLPlugin,
+  type QuerySourceMapEntry,
   type TargetContext,
   type TargetMatch,
 } from "@ts-safeql/plugin-utils";
@@ -26,6 +29,7 @@ import {
 import { isInEditorEnv } from "../utils/is-in-editor";
 import { memoize } from "../utils/memoize";
 import { locateNearestPackageJsonDir } from "../utils/node.utils";
+import { hasParserServicesWithTypeInformation } from "../utils/parser-services";
 import { mapTemplateLiteralToQueryText } from "../utils/ts-pg.utils";
 import { workers } from "../workers";
 import { WorkerError, WorkerResult } from "../workers/check-sql.worker";
@@ -44,8 +48,8 @@ import {
   TypeTransformer,
   getFinalResolvedTargetString,
   getResolvedTargetComparableString,
+  getResolvedTargetsEquality,
   getResolvedTargetString,
-  normalizeAnyForComparison,
   reportBaseError,
   reportDuplicateColumns,
   reportIncorrectTypeAnnotations,
@@ -55,7 +59,6 @@ import {
   reportMissingTypeAnnotations,
   reportPostgresError,
   shouldLintFile,
-  transformTypes,
 } from "./check-sql.utils";
 import z from "zod";
 
@@ -78,10 +81,17 @@ interface PluginContext {
   targetMatch: TargetMatch | false | undefined;
 }
 
+type CheckNode = TSESTree.Node;
+
+type TerminalCallQuery = {
+  text: string;
+  sourcemaps: QuerySourceMapEntry[];
+};
+
 function check(params: {
   context: RuleContext;
   config: Config;
-  tag: TSESTree.TaggedTemplateExpression;
+  tag: CheckNode;
   projectDir: string;
 }) {
   const connections = Array.isArray(params.config.connections)
@@ -92,32 +102,178 @@ function check(params: {
     const plugins = resolveConnectionPlugins(rawConnection, params.projectDir);
     const connection = applyPluginDefaults(rawConnection, plugins);
     const targetCtx = plugins.length > 0 ? getTargetContext(params.context) : undefined;
-    const targetMatch = resolvePluginTargetMatch(plugins, params.tag, targetCtx);
+    const targetMatch =
+      params.tag.type === "TaggedTemplateExpression"
+        ? resolvePluginTargetMatch(plugins, params.tag, targetCtx)
+        : undefined;
     const pluginCtx: PluginContext = { plugins, targetMatch };
 
     const targets = connection.targets ?? [];
 
+    if (
+      params.tag.type === "CallExpression" &&
+      !anyPluginClaimsCallExpression(plugins, params.tag)
+    ) {
+      continue;
+    }
+
     if (targets.length === 0 && targetMatch) {
       reportCheck({
         ...params,
+        tag: params.tag,
         connection,
         target: {
           tag: { regex: ".*" },
           skipTypeAnnotations: targetMatch.skipTypeAnnotations,
         },
         pluginCtx,
-        baseNode: params.tag.tag,
-        typeParameter: params.tag.typeArguments,
+        baseNode: getBaseNodeFromCheckNode(params.tag),
+        typeParameter:
+          params.tag.type === "TaggedTemplateExpression" ? params.tag.typeArguments : undefined,
       });
       continue;
     }
 
+    // A builder query has no tag, so it validates regardless of the connection's tag `targets`.
+    if (params.tag.type === "CallExpression") {
+      const query = resolveQueryFromPlugins({
+        node: params.tag,
+        plugins,
+        context: params.context,
+      });
+
+      if (query === undefined) {
+        continue;
+      }
+
+      // A builder query has no tag/target to match on, so it validates against the
+      // first connection whose plugins resolve it (one query → one report).
+      return reportCheck({
+        context: params.context,
+        projectDir: params.projectDir,
+        connection,
+        tag: params.tag,
+        target: {
+          tag: { regex: ".*" },
+        },
+        baseNode: getBaseNodeFromCheckNode(params.tag),
+        typeParameter: params.tag.typeArguments,
+        query,
+      });
+    }
+
     if (targets.length > 0) {
       for (const target of targets) {
-        checkConnection({ ...params, connection, target, pluginCtx });
+        if (params.tag.type === "TaggedTemplateExpression") {
+          checkConnection({ ...params, tag: params.tag, connection, target, pluginCtx });
+        }
       }
     }
   }
+}
+
+function anyPluginClaimsCallExpression(
+  plugins: SafeQLPlugin[],
+  node: TSESTree.CallExpression,
+): boolean {
+  return plugins.some((plugin) =>
+    (plugin.queryNodeKinds ?? []).some((selector) => matchesQueryNodeSelector(node, selector)),
+  );
+}
+
+// Resolved once per file so the visitor gates without re-resolving plugins per node; returns []
+// (without resolving plugins) when no connection declares any, keeping the no-plugin case free.
+function collectCallExpressionSelectors(config: Config, projectDir: string): QueryNodeSelector[] {
+  const connections = Array.isArray(config.connections) ? config.connections : [config.connections];
+
+  if (!connections.some((connection) => "plugins" in connection && connection.plugins?.length)) {
+    return [];
+  }
+
+  const selectors: QueryNodeSelector[] = [];
+  for (const connection of connections) {
+    for (const plugin of resolveConnectionPlugins(connection, projectDir)) {
+      for (const selector of plugin.queryNodeKinds ?? []) {
+        if (selector.kind === "CallExpression") {
+          selectors.push(selector);
+        }
+      }
+    }
+  }
+  return selectors;
+}
+
+function getBaseNodeFromCheckNode(node: CheckNode): TSESTree.Node {
+  if (node.type === "TaggedTemplateExpression") {
+    return node.tag;
+  }
+
+  if (node.type === "CallExpression") {
+    return node.callee;
+  }
+
+  return node;
+}
+
+function resolveQueryFromPlugins(params: {
+  node: TSESTree.Node;
+  plugins: SafeQLPlugin[];
+  context: RuleContext;
+}): TerminalCallQuery | undefined {
+  const targetCtx = getTargetContext(params.context);
+  if (targetCtx === undefined) {
+    return undefined;
+  }
+
+  const tsNode = targetCtx.parser.esTreeNodeToTSNodeMap.get(params.node);
+  if (!tsNode) {
+    return undefined;
+  }
+
+  // Built once and shared across candidate plugins; the type is computed lazily on first
+  // access, so a plugin that gates syntactically and never reads it pays no checker cost.
+  let cachedType: ts.Type | undefined;
+  let cachedTypeText: string | undefined;
+  const resolveContext = {
+    checker: targetCtx.checker,
+    parser: targetCtx.parser,
+    precedingSQL: "",
+    tsNode,
+    get tsType(): ts.Type {
+      return (cachedType ??= targetCtx.checker.getTypeAtLocation(tsNode));
+    },
+    get tsTypeText(): string {
+      return (cachedTypeText ??= targetCtx.checker.typeToString(this.tsType));
+    },
+  };
+
+  const isCallExpression = params.node.type === "CallExpression";
+
+  for (const plugin of params.plugins) {
+    if (!plugin.resolveQuery) {
+      continue;
+    }
+
+    if (
+      isCallExpression &&
+      !anyPluginClaimsCallExpression([plugin], params.node as TSESTree.CallExpression)
+    ) {
+      continue;
+    }
+
+    const result = plugin.resolveQuery(resolveContext);
+
+    if (result === "skip" || result === undefined) {
+      continue;
+    }
+
+    return {
+      text: result.text,
+      sourcemaps: result.sourcemaps,
+    };
+  }
+
+  return undefined;
 }
 
 function isTagMemberValid(
@@ -309,15 +465,26 @@ function reportPluginTypeCheck(params: {
 
 function reportCheck(params: {
   context: RuleContext;
-  tag: TSESTree.TaggedTemplateExpression;
+  tag: CheckNode;
   connection: RuleOptionConnection;
   target: ConnectionTarget;
   projectDir: string;
-  typeParameter: TSESTree.TSTypeParameterInstantiation | undefined;
-  baseNode: TSESTree.BaseNode;
+  typeParameter?: TSESTree.TSTypeParameterInstantiation;
+  baseNode: TSESTree.Node;
+  query?: TerminalCallQuery;
   pluginCtx?: PluginContext;
 }) {
-  const { context, tag, connection, target, projectDir, typeParameter, baseNode } = params;
+  const {
+    context,
+    tag,
+    connection,
+    target,
+    projectDir,
+    typeParameter,
+    baseNode,
+    query: overrideQuery,
+  } = params;
+  const queryTypeParameter = typeParameter;
 
   if (fatalError !== undefined) {
     const hint = isInEditorEnv()
@@ -343,14 +510,18 @@ function reportCheck(params: {
         : E.right(parser.program.getTypeChecker());
     }),
     E.bindW("query", ({ parser, checker }) =>
-      mapTemplateLiteralToQueryText(
-        tag.quasi,
-        parser,
-        checker,
-        params.connection,
-        params.context.sourceCode,
-        params.pluginCtx?.plugins,
-      ),
+      overrideQuery !== undefined
+        ? E.right(overrideQuery)
+        : tag.type === "TaggedTemplateExpression"
+          ? mapTemplateLiteralToQueryText(
+              tag.quasi,
+              parser,
+              checker,
+              params.connection,
+              params.context.sourceCode,
+              params.pluginCtx?.plugins,
+            )
+          : E.right(null),
     ),
     E.bindW("result", ({ query }) => {
       if (query === null) {
@@ -397,13 +568,13 @@ function reportCheck(params: {
         const pluginTypeCheck =
           params.pluginCtx?.targetMatch && params.pluginCtx.targetMatch.typeCheck;
 
-        if (pluginTypeCheck && result.output) {
+        if (pluginTypeCheck && result.output && tag.type === "TaggedTemplateExpression") {
           return reportPluginTypeCheck({
-            context: context,
-            tag: tag,
-            connection: connection,
-            checker: checker,
-            parser: parser,
+            context,
+            tag,
+            connection,
+            checker,
+            parser,
             output: result.output,
             typeCheck: pluginTypeCheck,
           });
@@ -413,28 +584,6 @@ function reportCheck(params: {
 
         if (shouldSkipTypeAnnotations) {
           return;
-        }
-
-        const isMissingTypeAnnotations = typeParameter === undefined;
-
-        if (isMissingTypeAnnotations) {
-          if (result.output === null) {
-            return;
-          }
-
-          return reportMissingTypeAnnotations({
-            tag: tag,
-            context: context,
-            baseNode: baseNode,
-            actual: getFinalResolvedTargetString({
-              target: result.output,
-              nullAsOptional: nullAsOptional ?? false,
-              nullAsUndefined: nullAsUndefined ?? false,
-              transform: target.transform,
-              inferLiterals: connection.inferLiterals ?? defaultInferLiteralOptions,
-            }),
-            enforceType: connection.enforceType,
-          });
         }
 
         const reservedTypes = memoize({
@@ -454,9 +603,38 @@ function reportCheck(params: {
           },
         });
 
+        // A terminal taking no `<T>` infers its row type from the builder's own
+        // schema, so it needs no annotation check; only the embedded raw `sql`
+        // (validated above) matters. A `<T>` terminal falls through below.
+        if (tag.type === "CallExpression" && !calleeAcceptsTypeArgument(tag, checker, parser)) {
+          return;
+        }
+
+        const isMissingTypeAnnotations = queryTypeParameter === undefined;
+
+        if (isMissingTypeAnnotations) {
+          if (result.output === null) {
+            return;
+          }
+
+          return reportMissingTypeAnnotations({
+            tag: tag,
+            context: context,
+            baseNode: baseNode,
+            actual: getFinalResolvedTargetString({
+              target: result.output,
+              nullAsOptional: connection.nullAsOptional ?? false,
+              nullAsUndefined: connection.nullAsUndefined ?? false,
+              transform: target.transform,
+              inferLiterals: connection.inferLiterals ?? defaultInferLiteralOptions,
+            }),
+            enforceType: connection.enforceType,
+          });
+        }
+
         const typeAnnotationState = getTypeAnnotationState({
           generated: result.output,
-          typeParameter: typeParameter,
+          typeParameter: queryTypeParameter,
           transform: target.transform,
           checker: checker,
           parser: parser,
@@ -469,14 +647,14 @@ function reportCheck(params: {
         if (typeAnnotationState === "INVALID") {
           return reportInvalidTypeAnnotations({
             context: context,
-            typeParameter: typeParameter,
+            typeParameter: queryTypeParameter,
           });
         }
 
         if (!typeAnnotationState.isEqual) {
           return reportIncorrectTypeAnnotations({
             context,
-            typeParameter: typeParameter,
+            typeParameter: queryTypeParameter,
             expected: fmap(typeAnnotationState.expected, (expected) =>
               getResolvedTargetString({
                 target: expected,
@@ -502,10 +680,21 @@ function reportCheck(params: {
   );
 }
 
-function hasParserServicesWithTypeInformation(
-  parser: Partial<ParserServices> | undefined,
-): parser is ParserServicesWithTypeInformation {
-  return parser !== undefined && parser.program !== null;
+// True when the terminal declares its own `<T>` (annotation model); false when the row type comes from the receiver.
+function calleeAcceptsTypeArgument(
+  node: TSESTree.CallExpression,
+  checker: ts.TypeChecker,
+  parser: ParserServicesWithTypeInformation,
+): boolean {
+  const tsCall = parser.esTreeNodeToTSNodeMap.get(node);
+  if (tsCall === undefined || !ts.isCallExpression(tsCall)) {
+    return false;
+  }
+
+  return checker
+    .getTypeAtLocation(tsCall.expression)
+    .getCallSignatures()
+    .some((signature) => (signature.getTypeParameters()?.length ?? 0) > 0);
 }
 
 function checkConnectionByTagExpression(params: {
@@ -584,7 +773,7 @@ function checkConnectionByWrapperExpression(params: {
 
 type GetTypeAnnotationStateParams = {
   generated: ResolvedTarget | null;
-  typeParameter: TSESTree.TSTypeParameterInstantiation;
+  typeParameter?: TSESTree.TSTypeParameterInstantiation;
   transform?: TypeTransformer;
   parser: ParserServices;
   checker: ts.TypeChecker;
@@ -605,18 +794,20 @@ function getTypeAnnotationState({
   nullAsUndefined,
   inferLiterals,
 }: GetTypeAnnotationStateParams) {
-  if (typeParameter.params.length !== 1) {
+  if (typeParameter !== undefined && typeParameter.params.length !== 1) {
     return "INVALID" as const;
   }
 
-  const typeNode = typeParameter.params[0];
-
-  const expected = getResolvedTargetByTypeNode({
+  const expected = getExpectedTarget({
+    typeNode: typeParameter?.params.at(0),
     checker,
     parser,
-    typeNode,
     reservedTypes,
   });
+
+  if (expected === null) {
+    return "INVALID" as const;
+  }
 
   return getResolvedTargetsEquality({
     expected,
@@ -628,69 +819,27 @@ function getTypeAnnotationState({
   });
 }
 
-function getResolvedTargetsEquality(params: {
-  expected: ExpectedResolvedTarget | null;
-  generated: ResolvedTarget | null;
-  nullAsOptional: boolean;
-  nullAsUndefined: boolean;
-  inferLiterals: InferLiteralsOption;
-  transform?: TypeTransformer;
-}) {
-  if (params.expected === null && params.generated === null) {
-    return {
-      isEqual: true,
-      expected: params.expected,
-      generated: params.generated,
-    };
+function getExpectedTarget({
+  typeNode,
+  checker,
+  parser,
+  reservedTypes,
+}: {
+  typeNode?: TSESTree.TypeNode;
+  checker: ts.TypeChecker;
+  parser: ParserServices;
+  reservedTypes: Set<string>;
+}): ExpectedResolvedTarget | null {
+  if (typeNode === undefined) {
+    return null;
   }
 
-  if (params.expected === null || params.generated === null) {
-    return {
-      isEqual: false,
-      expected: params.expected,
-      generated: params.generated,
-    };
-  }
-
-  // Normalized values are only used for the equality check below; the originals
-  // are returned unchanged for the error message.
-  const normalized = normalizeAnyForComparison(params.expected, params.generated);
-
-  let expectedString = getResolvedTargetComparableString({
-    target: normalized.expected,
-    nullAsOptional: false,
-    nullAsUndefined: false,
-    inferLiterals: params.inferLiterals,
+  return getResolvedTargetByTypeNode({
+    checker,
+    parser,
+    typeNode,
+    reservedTypes,
   });
-
-  let generatedString = getResolvedTargetComparableString({
-    target: normalized.generated,
-    nullAsOptional: params.nullAsOptional,
-    nullAsUndefined: params.nullAsUndefined,
-    inferLiterals: params.inferLiterals,
-  });
-
-  if (expectedString === null || generatedString === null) {
-    return {
-      isEqual: false,
-      expected: params.expected,
-      generated: params.generated,
-    };
-  }
-
-  expectedString = expectedString.replace(/'/g, '"');
-  generatedString = generatedString.replace(/'/g, '"');
-
-  // The comparable form is already canonical, so no further reordering is needed.
-  if (params.transform !== undefined) {
-    generatedString = transformTypes(generatedString, params.transform);
-  }
-
-  return {
-    isEqual: expectedString === generatedString,
-    expected: params.expected,
-    generated: params.generated,
-  };
 }
 
 const createRule = ESLintUtils.RuleCreator(() => `https://github.com/ts-safeql/safeql`)<
@@ -726,10 +875,28 @@ export default createRule({
       value: () => getConfigFromFileWithContext({ context, projectDir }),
     });
 
-    return {
+    const callExpressionSelectors = memoize({
+      key: JSON.stringify({ key: "call-selectors", options: context.options, projectDir }),
+      value: () => collectCallExpressionSelectors(config, projectDir),
+    });
+
+    const listener: TSESLint.RuleListener = {
       TaggedTemplateExpression(tag) {
         check({ context, tag, config, projectDir });
       },
     };
+
+    // Files without a builder plugin never pay the per-CallExpression visit.
+    if (callExpressionSelectors.length > 0) {
+      listener.CallExpression = (node) => {
+        if (!callExpressionSelectors.some((selector) => matchesQueryNodeSelector(node, selector))) {
+          return;
+        }
+
+        check({ context, tag: node, config, projectDir });
+      };
+    }
+
+    return listener;
   },
 });

--- a/packages/eslint-plugin/src/rules/check-sql.utils.ts
+++ b/packages/eslint-plugin/src/rules/check-sql.utils.ts
@@ -105,7 +105,7 @@ export function reportInvalidQueryError(params: {
 
 export function reportBaseError(params: {
   context: RuleContext;
-  tag: TSESTree.TaggedTemplateExpression;
+  tag: TSESTree.Node;
   error: WorkerError;
   hint?: string;
 }) {
@@ -123,7 +123,7 @@ export function reportBaseError(params: {
 }
 
 export function reportInvalidConfig(params: {
-  tag: TSESTree.TaggedTemplateExpression;
+  tag: TSESTree.Node;
   context: RuleContext;
   error: InvalidConfigError;
 }) {
@@ -132,7 +132,7 @@ export function reportInvalidConfig(params: {
   return context.report({
     node: tag,
     messageId: "invalidQuery",
-    loc: context.sourceCode.getLocFromIndex(tag.quasi.range[0]),
+    loc: context.sourceCode.getLocFromIndex(getNodeStartOffset(tag)),
     data: {
       error: error.message,
     },
@@ -140,7 +140,7 @@ export function reportInvalidConfig(params: {
 }
 
 export function reportDuplicateColumns(params: {
-  tag: TSESTree.TaggedTemplateExpression;
+  tag: TSESTree.Node;
   context: RuleContext;
   error: DuplicateColumnsError;
 }) {
@@ -164,7 +164,7 @@ export function reportDuplicateColumns(params: {
 
 export function reportPostgresError(params: {
   context: RuleContext;
-  tag: TSESTree.TaggedTemplateExpression;
+  tag: TSESTree.Node;
   error: PostgresError;
 }) {
   const { context, tag, error } = params;
@@ -187,8 +187,8 @@ export function reportPostgresError(params: {
 
 export function reportMissingTypeAnnotations(params: {
   context: RuleContext;
-  tag: TSESTree.TaggedTemplateExpression;
-  baseNode: TSESTree.BaseNode;
+  tag: TSESTree.Node;
+  baseNode: TSESTree.Node;
   actual: string;
   enforceType?: EnforceTypeOption;
 }) {
@@ -260,7 +260,7 @@ export function getDatabaseName(params: {
   return `safeql_${projectUnderscoreName}_${hash}`;
 }
 
-export function shouldLintFile(params: RuleContext) {
+export function shouldLintFile(params: { filename: string }) {
   const fileName = params.filename;
 
   for (const extension of ["ts", "tsx", "mts", "mtsx"]) {
@@ -502,6 +502,14 @@ function alignAny(
     ];
   }
 
+  if (expected.kind === "literal" && generated.kind === "literal") {
+    const [base, generatedBase] = alignAny(expected.base, generated.base);
+    return [
+      { kind: "literal", value: expected.value, base },
+      { kind: "literal", value: generated.value, base: generatedBase },
+    ];
+  }
+
   return [expected, generated];
 }
 
@@ -577,6 +585,70 @@ export function getResolvedTargetComparableString(params: {
       return `{ ${entriesString} }`;
     }
   }
+}
+
+export function getResolvedTargetsEquality(params: {
+  expected: ExpectedResolvedTarget | null;
+  generated: ResolvedTarget | null;
+  nullAsOptional: boolean;
+  nullAsUndefined: boolean;
+  inferLiterals: InferLiteralsOption;
+  transform?: TypeTransformer;
+}) {
+  if (params.expected === null && params.generated === null) {
+    return {
+      isEqual: true,
+      expected: params.expected,
+      generated: params.generated,
+    };
+  }
+
+  if (params.expected === null || params.generated === null) {
+    return {
+      isEqual: false,
+      expected: params.expected,
+      generated: params.generated,
+    };
+  }
+
+  // Normalized only for the equality check; originals are returned for the error message.
+  const normalized = normalizeAnyForComparison(params.expected, params.generated);
+
+  let expectedString = getResolvedTargetComparableString({
+    target: normalized.expected,
+    nullAsOptional: false,
+    nullAsUndefined: false,
+    inferLiterals: params.inferLiterals,
+  });
+
+  let generatedString = getResolvedTargetComparableString({
+    target: normalized.generated,
+    nullAsOptional: params.nullAsOptional,
+    nullAsUndefined: params.nullAsUndefined,
+    inferLiterals: params.inferLiterals,
+  });
+
+  if (expectedString === null || generatedString === null) {
+    return {
+      isEqual: false,
+      expected: params.expected,
+      generated: params.generated,
+    };
+  }
+
+  expectedString = expectedString.replace(/'/g, '"');
+  generatedString = generatedString.replace(/'/g, '"');
+
+  // The comparable form is already canonical, so no further reordering is needed.
+  if (params.transform !== undefined) {
+    generatedString = transformTypes(generatedString, params.transform);
+  }
+
+  return {
+    isEqual: expectedString === generatedString,
+    expected: params.expected,
+    generated: params.generated,
+  };
 }
 
 export function getResolvedTargetString(params: {
@@ -664,7 +736,7 @@ interface GetWordRangeInPositionParams {
     position: number;
     sourcemaps: QuerySourceMapEntry[];
   };
-  tag: TSESTree.TaggedTemplateExpression;
+  tag: TSESTree.Node;
   sourceCode: Readonly<SourceCode>;
 }
 
@@ -686,7 +758,7 @@ function getQueryErrorPosition({ error, tag, sourceCode }: GetWordRangeInPositio
   const syntaxErrorToken = error.message.match(/syntax error at or near "([^"]+)"/)?.[1];
 
   if (syntaxErrorToken) {
-    const templateText = sourceCode.text.slice(tag.quasi.range[0], tag.quasi.range[1]);
+    const templateText = sourceCode.text.slice(getNodeStartOffset(tag), tag.range[1]);
     const tokenIndex = findNearestMatchIndex(templateText, syntaxErrorToken, sourceRange[0]);
 
     if (tokenIndex !== undefined) {
@@ -743,13 +815,14 @@ function findNearestMatchIndex(text: string, searchText: string, position: numbe
 }
 
 function getSourceLocation(
-  tag: TSESTree.TaggedTemplateExpression,
+  tag: TSESTree.Node,
   sourceCode: Readonly<SourceCode>,
   range: [number, number],
   extendToWord = false,
 ): TSESTree.SourceLocation {
-  const start = sourceCode.getLocFromIndex(tag.quasi.range[0] + range[0]);
-  const end = sourceCode.getLocFromIndex(tag.quasi.range[0] + range[1]);
+  const tagStart = getNodeStartOffset(tag);
+  const start = sourceCode.getLocFromIndex(tagStart + range[0]);
+  const end = sourceCode.getLocFromIndex(tagStart + range[1]);
 
   if (!extendToWord) {
     return { start, end };
@@ -765,4 +838,8 @@ function getSourceLocation(
       column: end.column + wordLength,
     },
   };
+}
+
+function getNodeStartOffset(node: TSESTree.Node) {
+  return "quasi" in node ? node.quasi.range[0] : node.range[0];
 }

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.call-query.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.call-query.test.ts
@@ -1,0 +1,297 @@
+import { normalizeIndent } from "@ts-safeql/shared";
+import path from "path";
+import { checkSqlRule, ruleTester, setupCheckSqlRuleTester } from "./check-sql.test-utils";
+
+const { withConnection, connections } = setupCheckSqlRuleTester();
+
+const callQueryPlugin = {
+  package: path.resolve(__dirname, "../ts-fixture/call-query-plugin.ts"),
+  config: {},
+};
+
+const callQueryCustomMethodPlugin = {
+  package: path.resolve(__dirname, "../ts-fixture/call-query-custom-method-plugin.ts"),
+  config: {},
+};
+
+function options(overrides: Partial<Parameters<typeof withConnection>[0]> = {}) {
+  return withConnection({
+    ...connections.base,
+    keepAlive: false,
+    targets: [],
+    plugins: [callQueryPlugin],
+    ...overrides,
+  });
+}
+
+ruleTester.run("call expression plugin query", checkSqlRule, {
+  valid: [
+    {
+      options: options({ enforceType: "suggest" }),
+      code: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run<{ one: number }>();
+      `,
+    },
+    {
+      name: "non-terminal methods are ignored even when query plugin is present",
+      options: options(),
+      code: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+          notATerminalMethod<T>(): Promise<T>;
+        };
+
+        db.notATerminalMethod();
+      `,
+    },
+    {
+      options: options(),
+      code: normalizeIndent`
+        declare const db: {
+          prepare<T>(): { sql: string };
+          run<T>(): Promise<T>;
+          get<T>(): Promise<T>;
+          getOrThrow<T>(): Promise<T>;
+          iterate<T>(): AsyncIterable<T>;
+        };
+
+        db.prepare<{ one: number }>();
+        db.run<{ one: number }>();
+        db.get<{ one: number }>();
+        db.getOrThrow<{ one: number }>();
+        db.iterate<{ one: number }>();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      options: options(),
+      code: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run();
+      `,
+      output: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run<{ one: number }>();
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      options: options({ enforceType: "suggest" }),
+      code: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run();
+      `,
+      errors: [
+        {
+          messageId: "missingTypeAnnotations",
+          suggestions: [
+            {
+              messageId: "missingTypeAnnotations",
+              output: normalizeIndent`
+                declare const db: {
+                  run<T>(): Promise<T>;
+                };
+
+                db.run<{ one: number }>();
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      options: options(),
+      code: normalizeIndent`
+        declare const db: {
+          query: {
+            run<T>(): Promise<T>;
+          };
+        };
+
+        db.query.run();
+      `,
+      output: normalizeIndent`
+        declare const db: {
+          query: {
+            run<T>(): Promise<T>;
+          };
+        };
+
+        db.query.run<{ one: number }>();
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+    {
+      options: options({ enforceType: "suggest" }),
+      code: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run<{ one: string }>();
+      `,
+      errors: [
+        {
+          messageId: "incorrectTypeAnnotations",
+          suggestions: [
+            {
+              messageId: "incorrectTypeAnnotations",
+              output: normalizeIndent`
+                declare const db: {
+                  run<T>(): Promise<T>;
+                };
+
+                db.run<{ one: number }>();
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      options: options(),
+      code: normalizeIndent`
+        declare const db: {
+          get<T>(): Promise<T>;
+          getOrThrow<T>(): Promise<T>;
+        };
+
+        db.get();
+        db.getOrThrow();
+      `,
+      output: normalizeIndent`
+        declare const db: {
+          get<T>(): Promise<T>;
+          getOrThrow<T>(): Promise<T>;
+        };
+
+        db.get<{ one: number }>();
+        db.getOrThrow<{ one: number }>();
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }, { messageId: "missingTypeAnnotations" }],
+    },
+  ],
+});
+
+ruleTester.run("call expression plugin with a custom method name", checkSqlRule, {
+  valid: [
+    {
+      options: withConnection({
+        ...connections.base,
+        keepAlive: false,
+        targets: [],
+        plugins: [callQueryCustomMethodPlugin],
+      }),
+      code: normalizeIndent`
+        declare const db: {
+          runRawQuery<T>(): Promise<T>;
+        };
+
+        db.runRawQuery<{ one: number }>();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      options: withConnection({
+        ...connections.base,
+        keepAlive: false,
+        targets: [],
+        plugins: [callQueryCustomMethodPlugin],
+      }),
+      code: normalizeIndent`
+        declare const db: {
+          runRawQuery<T>(): Promise<T>;
+        };
+
+        db.runRawQuery();
+      `,
+      output: normalizeIndent`
+        declare const db: {
+          runRawQuery<T>(): Promise<T>;
+        };
+
+        db.runRawQuery<{ one: number }>();
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+  ],
+});
+
+// A builder query has no tag, so it must still be validated when the connection also declares
+// tag `targets` (otherwise builder calls would be silently skipped on such connections).
+ruleTester.run("call expression plugin alongside tag targets", checkSqlRule, {
+  valid: [
+    {
+      options: withConnection({
+        ...connections.base,
+        keepAlive: false,
+        targets: [{ tag: "sql" }],
+        plugins: [callQueryPlugin],
+      }),
+      code: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run<{ one: number }>();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      options: withConnection({
+        ...connections.base,
+        keepAlive: false,
+        targets: [{ tag: "sql" }],
+        plugins: [callQueryPlugin],
+      }),
+      code: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run();
+      `,
+      output: normalizeIndent`
+        declare const db: {
+          run<T>(): Promise<T>;
+        };
+
+        db.run<{ one: number }>();
+      `,
+      errors: [{ messageId: "missingTypeAnnotations" }],
+    },
+  ],
+});
+
+ruleTester.run("call expression plugin with multiple type arguments", checkSqlRule, {
+  valid: [],
+  invalid: [
+    {
+      options: options(),
+      code: normalizeIndent`
+        declare const db: {
+          run<A, B>(): Promise<A>;
+        };
+
+        db.run<{ one: number }, { two: number }>();
+      `,
+      errors: [{ messageId: "invalidTypeAnnotations" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.plugins.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.plugins.test.ts
@@ -74,7 +74,7 @@ ruleTester.run("plugin priority", checkSqlRule, {
           declare function sql(strings: TemplateStringsArray, ...values: unknown[]): unknown;
 
           sql\`TOTAL GARBAGE\`;
-        `,
+      `,
     },
   ],
   invalid: [],

--- a/packages/eslint-plugin/src/rules/check-sql/check-sql.utils.test.ts
+++ b/packages/eslint-plugin/src/rules/check-sql/check-sql.utils.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { ExpectedResolvedTarget } from "../../utils/get-resolved-target-by-type-node";
+import { ResolvedTarget } from "@ts-safeql/generate";
+import { getResolvedTargetsEquality, getResolvedTargetComparableString } from "../check-sql.utils";
+
+describe("check-sql.utils type comparison", () => {
+  it("considers both expected and generated unknown as equal", () => {
+    const result = getResolvedTargetsEquality({
+      expected: null,
+      generated: null,
+      nullAsOptional: false,
+      nullAsUndefined: false,
+      inferLiterals: false,
+    });
+
+    expect(result).toEqual({
+      isEqual: true,
+      expected: null,
+      generated: null,
+    });
+  });
+
+  it("returns false when one side is missing", () => {
+    const expected: ExpectedResolvedTarget = {
+      kind: "type",
+      value: "number",
+    };
+
+    const generated: ResolvedTarget = {
+      kind: "type",
+      value: "number",
+      type: "number",
+    };
+
+    expect(
+      getResolvedTargetsEquality({
+        expected,
+        generated: null,
+        nullAsOptional: false,
+        nullAsUndefined: false,
+        inferLiterals: false,
+      }).isEqual,
+    ).toBe(false);
+
+    expect(
+      getResolvedTargetsEquality({
+        expected: null,
+        generated,
+        nullAsOptional: false,
+        nullAsUndefined: false,
+        inferLiterals: false,
+      }).isEqual,
+    ).toBe(false);
+  });
+
+  it("normalizes object properties before comparison", () => {
+    const expected: ExpectedResolvedTarget = {
+      kind: "object",
+      value: [["id", { kind: "type", value: "number" }]],
+    };
+
+    const generated: ResolvedTarget = {
+      kind: "object",
+      value: [["id", { kind: "type", value: "number", type: "number" }]],
+    };
+
+    expect(
+      getResolvedTargetsEquality({
+        expected,
+        generated,
+        nullAsOptional: false,
+        nullAsUndefined: false,
+        inferLiterals: false,
+      }),
+    ).toMatchObject({
+      isEqual: true,
+    });
+  });
+
+  it("applies transform before comparing generated vs expected", () => {
+    const expected: ExpectedResolvedTarget = {
+      kind: "type",
+      value: "string",
+    };
+
+    const generated: ResolvedTarget = {
+      kind: "type",
+      value: "text",
+      type: "text",
+    };
+
+    const transformed = getResolvedTargetsEquality({
+      expected,
+      generated,
+      nullAsOptional: false,
+      nullAsUndefined: false,
+      inferLiterals: false,
+      transform: [["text", "string"]],
+    });
+
+    expect(transformed).toMatchObject({ isEqual: true });
+    expect(
+      getResolvedTargetComparableString({
+        target: transformed.expected!,
+        nullAsOptional: false,
+        nullAsUndefined: false,
+        inferLiterals: false,
+      }),
+    ).toBe("string");
+  });
+
+  it("returns deterministic stringified types for array/object comparisons", () => {
+    const expected: ExpectedResolvedTarget = {
+      kind: "array",
+      value: { kind: "type", value: "number" },
+    };
+
+    const generated: ResolvedTarget = {
+      kind: "array",
+      value: { kind: "type", value: "number", type: "number" },
+    };
+
+    expect(
+      getResolvedTargetComparableString({
+        target: expected,
+        nullAsOptional: false,
+        nullAsUndefined: false,
+        inferLiterals: false,
+      }),
+    ).toBe("number[]");
+    expect(
+      getResolvedTargetComparableString({
+        target: generated,
+        nullAsOptional: false,
+        nullAsUndefined: false,
+        inferLiterals: false,
+      }),
+    ).toBe("number[]");
+  });
+
+  it("treats `any` nested in a literal base as compatible", () => {
+    const expected: ExpectedResolvedTarget = {
+      kind: "literal",
+      value: '"a"',
+      base: { kind: "type", value: "any" },
+    };
+
+    const generated: ResolvedTarget = {
+      kind: "literal",
+      value: '"a"',
+      base: { kind: "type", value: "string", type: "string" },
+    };
+
+    expect(
+      getResolvedTargetsEquality({
+        expected,
+        generated,
+        nullAsOptional: false,
+        nullAsUndefined: false,
+        inferLiterals: false,
+      }),
+    ).toMatchObject({ isEqual: true });
+  });
+});

--- a/packages/eslint-plugin/src/rules/ts-fixture/call-query-custom-method-plugin.ts
+++ b/packages/eslint-plugin/src/rules/ts-fixture/call-query-custom-method-plugin.ts
@@ -1,0 +1,20 @@
+import { definePlugin } from "@ts-safeql/plugin-utils";
+
+export default definePlugin({
+  name: "call-query-custom-method-plugin",
+  package: "./src/rules/ts-fixture/call-query-custom-method-plugin.ts",
+  setup() {
+    return {
+      queryNodeKinds: [
+        { kind: "CallExpression", callee: { property: { nameIn: ["runRawQuery"] } } },
+      ],
+      resolveQuery() {
+        return {
+          kind: "sql",
+          text: "SELECT 1 AS one",
+          sourcemaps: [],
+        };
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/ts-fixture/call-query-plugin.ts
+++ b/packages/eslint-plugin/src/rules/ts-fixture/call-query-plugin.ts
@@ -1,0 +1,27 @@
+import { definePlugin } from "@ts-safeql/plugin-utils";
+
+export default definePlugin({
+  name: "call-query-dry-plugin",
+  package: "./src/rules/ts-fixture/call-query-plugin.ts",
+  setup() {
+    return {
+      queryNodeKinds: [
+        {
+          kind: "CallExpression",
+          callee: {
+            property: {
+              nameIn: ["run", "get", "getOrThrow", "prepare", "iterate"],
+            },
+          },
+        },
+      ],
+      resolveQuery() {
+        return {
+          kind: "sql",
+          text: "SELECT 1 AS one",
+          sourcemaps: [],
+        };
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/utils/get-resolved-target-by-type-node.test.ts
+++ b/packages/eslint-plugin/src/utils/get-resolved-target-by-type-node.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ParserServices, TSESTree } from "@typescript-eslint/utils";
+import ts from "typescript";
+import {
+  getResolvedTargetByType,
+  ExpectedResolvedTarget,
+  ExpectedResolvedTargetEntry,
+} from "./get-resolved-target-by-type-node";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("getResolvedTargetByType", () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "safeql-type-at-location-"));
+    filePath = path.join(tempDir, "fixture.ts");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("accepts a resolved TypeScript type and preserves object members", () => {
+    const source = `
+      type Person = {
+        id: number;
+        name: string | null;
+      };
+    `;
+
+    fs.writeFileSync(filePath, source);
+
+    const program = ts.createProgram({
+      rootNames: [filePath],
+      options: {
+        strict: true,
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.ESNext,
+      },
+      host: ts.createCompilerHost({
+        strict: true,
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.ESNext,
+      }),
+    });
+
+    const sourceFile = program.getSourceFile(filePath);
+    if (!sourceFile) {
+      throw new Error("Expected source file from synthetic fixture");
+    }
+
+    const checker = program.getTypeChecker();
+    const typeAlias = sourceFile.statements.find(
+      (statement): statement is ts.TypeAliasDeclaration => ts.isTypeAliasDeclaration(statement),
+    );
+
+    if (!typeAlias || !ts.isTypeAliasDeclaration(typeAlias)) {
+      throw new Error("Expected type alias statement");
+    }
+
+    const resolved = checker.getTypeAtLocation(typeAlias.type);
+
+    const comparable = getResolvedTargetByType({
+      type: resolved,
+      checker,
+      parser: {
+        esTreeNodeToTSNodeMap: {
+          get: (node: TSESTree.Node | ts.Node) => node as ts.Node,
+        },
+      } as ParserServices,
+      reservedTypes: new Set(["number", "string", "null"]),
+      anchorNode: typeAlias.type,
+    });
+
+    expect(comparable).toMatchObject({
+      kind: "object",
+      value: [
+        ["id", { kind: "type", value: "number" }],
+        ["name", expect.objectContaining({ kind: "union" })],
+      ],
+    });
+
+    expect(comparable.kind).toBe("object");
+
+    if (comparable.kind !== "object") {
+      return;
+    }
+
+    const nameType = comparable.value.find((entry: ExpectedResolvedTargetEntry) => {
+      const [key] = entry;
+      return key === "name";
+    })?.[1];
+
+    expect(nameType?.kind).toBe("union");
+
+    if (nameType?.kind === "union") {
+      const unionValues = nameType.value.map((entry: ExpectedResolvedTarget) => entry.value).sort();
+      expect(unionValues).toEqual(["null", "string"]);
+    }
+  });
+});

--- a/packages/eslint-plugin/src/utils/get-resolved-target-by-type-node.ts
+++ b/packages/eslint-plugin/src/utils/get-resolved-target-by-type-node.ts
@@ -2,10 +2,11 @@ import { ParserServices, TSESTree } from "@typescript-eslint/utils";
 import ts from "typescript";
 
 type GetResolvedTargetByTypeNodeParams = {
-  typeNode: TSESTree.TypeNode;
+  typeNode?: TSESTree.TypeNode;
   parser: ParserServices;
   checker: ts.TypeChecker;
   reservedTypes: Set<string>;
+  anchorNode?: ts.Node;
 };
 
 export type ExpectedResolvedTarget =
@@ -31,21 +32,26 @@ const PRIMITIVES = {
 export function getResolvedTargetByTypeNode(
   params: GetResolvedTargetByTypeNodeParams,
 ): ExpectedResolvedTarget {
+  if (!params.typeNode) {
+    return { kind: "type", value: "unknown" };
+  }
+
+  const typeNode = params.typeNode;
   const typeText = params.parser.esTreeNodeToTSNodeMap.get(params.typeNode).getText();
 
   if (isReservedType(typeText, params.reservedTypes)) {
     return { kind: "type", value: typeText };
   }
 
-  switch (params.typeNode.type) {
+  switch (typeNode.type) {
     case TSESTree.AST_NODE_TYPES.TSLiteralType:
-      return handleLiteralType(params.typeNode);
+      return handleLiteralType(typeNode);
 
     case TSESTree.AST_NODE_TYPES.TSUnionType:
       return {
         kind: "union",
-        value: params.typeNode.types.map((type) =>
-          getResolvedTargetByTypeNode({ ...params, typeNode: type }),
+        value: typeNode.types.map((type) =>
+          getResolvedTargetByTypeNode({ ...params, typeNode: type as TSESTree.TypeNode }),
         ),
       };
 
@@ -56,26 +62,45 @@ export function getResolvedTargetByTypeNode(
       return { kind: "type", value: "undefined" };
 
     case TSESTree.AST_NODE_TYPES.TSTypeLiteral:
-      return handleTypeLiteral(params.typeNode, params);
+      return handleTypeLiteral(typeNode, params);
 
     case TSESTree.AST_NODE_TYPES.TSTypeReference:
-      return handleTypeReference(params.typeNode, params);
+      return handleTypeReference(typeNode, params);
 
     case TSESTree.AST_NODE_TYPES.TSIntersectionType:
-      return handleIntersectionType(params.typeNode, params);
+      return handleIntersectionType(typeNode, params);
 
     case TSESTree.AST_NODE_TYPES.TSArrayType:
       return {
         kind: "array",
         value: getResolvedTargetByTypeNode({
           ...params,
-          typeNode: params.typeNode.elementType,
+          typeNode: typeNode.elementType,
         }),
       };
 
     default:
       return { kind: "type", value: typeText };
   }
+}
+
+export interface GetResolvedTargetByTypeParams {
+  type: ts.Type;
+  checker: ts.TypeChecker;
+  parser: ParserServices;
+  reservedTypes: Set<string>;
+  anchorNode?: ts.Node;
+}
+
+export function getResolvedTargetByType(
+  params: GetResolvedTargetByTypeParams,
+): ExpectedResolvedTarget {
+  return resolveTypeFromType(params.type, {
+    checker: params.checker,
+    parser: params.parser,
+    reservedTypes: params.reservedTypes,
+    anchorNode: params.anchorNode,
+  });
 }
 
 function isReservedType(typeText: string, reservedTypes: Set<string>): boolean {
@@ -307,16 +332,66 @@ function extractObjectProperties(
   type: ts.Type,
   params: GetResolvedTargetByTypeNodeParams,
 ): ExpectedResolvedTarget {
+  const typeLocation = toTypeScriptNode({
+    parser: params.parser,
+    node: params.typeNode ?? params.anchorNode,
+  });
+
+  if (typeLocation === undefined) {
+    return { kind: "object", value: [] };
+  }
+
   const properties = type.getProperties().map((property): ExpectedResolvedTargetEntry => {
     const key = property.escapedName.toString();
-    const propType = params.checker.getTypeOfSymbolAtLocation(
-      property,
-      params.parser.esTreeNodeToTSNodeMap.get(params.typeNode),
-    );
+    const propType = params.checker.getTypeOfSymbolAtLocation(property, typeLocation);
 
     const resolvedType = resolveType(propType, params);
     return [key, resolvedType];
   });
 
   return { kind: "object", value: properties };
+}
+
+function resolveTypeFromType(
+  type: ts.Type,
+  params: Omit<GetResolvedTargetByTypeParams, "type"> & {
+    typeNode?: TSESTree.TypeNode | ts.Node;
+    anchorNode?: ts.Node;
+  },
+): ExpectedResolvedTarget {
+  const typeLocation = toTypeScriptNode({
+    parser: params.parser,
+    node: params.typeNode ?? params.anchorNode,
+  });
+
+  if (!typeLocation) {
+    return resolveType(type, {
+      parser: params.parser,
+      checker: params.checker,
+      reservedTypes: params.reservedTypes,
+    });
+  }
+
+  return resolveType(type, {
+    parser: params.parser,
+    checker: params.checker,
+    reservedTypes: params.reservedTypes,
+    anchorNode: typeLocation,
+  });
+}
+
+function toTypeScriptNode(params: {
+  parser: ParserServices;
+  node?: TSESTree.Node | ts.Node;
+}): ts.Node | undefined {
+  if (params.node === undefined) {
+    return undefined;
+  }
+
+  const node = params.node;
+  if ("kind" in node) {
+    return node as ts.Node;
+  }
+
+  return params.parser.esTreeNodeToTSNodeMap.get(node as TSESTree.Node);
 }

--- a/packages/eslint-plugin/src/utils/parser-services.ts
+++ b/packages/eslint-plugin/src/utils/parser-services.ts
@@ -1,0 +1,7 @@
+import type { ParserServices, ParserServicesWithTypeInformation } from "@typescript-eslint/utils";
+
+export function hasParserServicesWithTypeInformation(
+  parser: Partial<ParserServices> | undefined,
+): parser is ParserServicesWithTypeInformation {
+  return parser !== undefined && parser.program !== null && parser.program !== undefined;
+}

--- a/packages/eslint-plugin/src/utils/ts-pg.utils.ts
+++ b/packages/eslint-plugin/src/utils/ts-pg.utils.ts
@@ -4,7 +4,7 @@ import {
   normalizeIndent,
   QuerySourceMapEntry,
 } from "@ts-safeql/shared";
-import type { SafeQLPlugin } from "@ts-safeql/plugin-utils";
+import { type SafeQLPlugin } from "@ts-safeql/plugin-utils";
 import { InvalidQueryError } from "../errors";
 import { TSESTreeToTSNode } from "@typescript-eslint/typescript-estree";
 import { ParserServices, TSESLint, TSESTree } from "@typescript-eslint/utils";
@@ -610,7 +610,7 @@ function checkType(params: {
   }
 
   // Template-literal types (`${number}`) and string-mapping types (`Uppercase<string>`) are strings
-  // at runtime → `text`. This also resolves branded `Money` (its `${number}` base now lands here).
+  // at runtime → `text`. Branded types like `Money` resolve here via their `${number}` base.
   if (type.flags & (ts.TypeFlags.TemplateLiteral | ts.TypeFlags.StringMapping)) {
     return E.right({ kind: "cast", cast: isArray ? "text[]" : "text" });
   }

--- a/packages/eslint-plugin/src/workers/check-sql.worker.test.ts
+++ b/packages/eslint-plugin/src/workers/check-sql.worker.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, inject, it } from "vitest";
+import { handler } from "./check-sql.worker";
+
+describe("check-sql worker", () => {
+  let tempDir: string;
+  let pluginPath: string;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "safeql-worker-plugin-"));
+    pluginPath = path.join(tempDir, "worker-hook-plugin.ts");
+    fs.writeFileSync(
+      pluginPath,
+      String.raw`
+import postgres from "postgres";
+
+export default {
+  factory(config: { databaseUrl: string }) {
+    return {
+      name: "safeql-worker-rule-only-hook-guard",
+      createConnection: {
+        cacheKey: "safeql-worker-rule-only-hook-guard://" + config.databaseUrl,
+        async handler() {
+          return postgres(config.databaseUrl);
+        },
+      },
+      resolveQuery() {
+        throw new Error("resolveQuery must not be called in worker path");
+      },
+    };
+  },
+};
+`,
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("ignores rule-only plugin hooks while executing worker validation", async () => {
+    const result = await handler({
+      connection: {
+        keepAlive: false,
+        plugins: [
+          {
+            package: pluginPath,
+            config: {
+              databaseUrl: inject("checkSqlDatabaseUrl"),
+            },
+          },
+        ],
+      },
+      target: { tag: "sql" },
+      query: {
+        text: "SELECT 1 AS one",
+        sourcemaps: [],
+      },
+      projectDir: tempDir,
+    });
+
+    const payload =
+      typeof result === "string"
+        ? (JSON.parse(result) as {
+            _tag: "Right" | "Left";
+            right?: unknown;
+            left?: unknown;
+          })
+        : (result as {
+            _tag: "Right" | "Left";
+            right?: unknown;
+            left?: unknown;
+          });
+
+    expect(payload).toMatchObject({ _tag: "Right" });
+
+    const workerResult =
+      typeof payload.right === "string"
+        ? (JSON.parse(payload.right) as { right: unknown })
+        : payload;
+    const generateResult =
+      "right" in workerResult ? (workerResult.right as { query: { text: string } }) : undefined;
+
+    expect(generateResult?.query.text).toBe("SELECT 1 AS one");
+  });
+});

--- a/packages/eslint-plugin/src/workers/check-sql.worker.ts
+++ b/packages/eslint-plugin/src/workers/check-sql.worker.ts
@@ -35,7 +35,7 @@ const generator = createGenerator();
 const connections = createConnectionManager();
 const watchers = createWatchManager();
 
-async function handler(params: CheckSQLWorkerParams) {
+export async function handler(params: CheckSQLWorkerParams) {
   const strategy = getConnectionStartegyByRuleOptionConnection({
     connection: params.connection,
     projectDir: params.projectDir,
@@ -50,10 +50,7 @@ async function handler(params: CheckSQLWorkerParams) {
     });
   }
 
-  const result = await pipe(
-    TE.Do,
-    TE.chain(() => workerHandler(params)),
-  )();
+  const result = await workerHandler(params)();
 
   if (params.connection.keepAlive === false) {
     connections.close(strategy);
@@ -73,10 +70,16 @@ export type WorkerError =
   | GenerateError;
 export type WorkerResult = GenerateResult;
 
-function workerHandler(params: CheckSQLWorkerParams): TE.TaskEither<WorkerError, WorkerResult> {
+/**
+ * Shared by the query and schema-introspection paths so both hit the same shadow DB.
+ */
+function resolveConnectionPayload(params: {
+  connection: RuleOptionConnection;
+  projectDir: string;
+}): TE.TaskEither<WorkerError, ConnectionPayload> {
   const strategy = getConnectionStartegyByRuleOptionConnection(params);
 
-  const connnectionPayload: TE.TaskEither<WorkerError, ConnectionPayload> = match(strategy)
+  return match(strategy)
     .with({ type: "databaseUrl" }, ({ databaseUrl }) =>
       TE.right(connections.getOrCreate(databaseUrl)),
     )
@@ -102,10 +105,34 @@ function workerHandler(params: CheckSQLWorkerParams): TE.TaskEither<WorkerError,
       if (isFirst) {
         const migrationsPath = path.join(params.projectDir, migrationsDir);
 
+        // A plugin's migrate hook replaces the built-in `.sql` runner. Plugin resolution
+        // can throw synchronously, so surface it as a worker error rather than crashing.
+        let pluginMigrate: ReturnType<typeof connections.resolveMigrate>;
+        try {
+          pluginMigrate = params.connection.plugins?.length
+            ? connections.resolveMigrate(params.connection.plugins, params.projectDir)
+            : undefined;
+        } catch (error) {
+          return TE.left(error instanceof PluginError ? error : PluginError.from("unknown")(error));
+        }
+
+        const applyMigrations: TE.TaskEither<WorkerError, unknown> = pluginMigrate
+          ? TE.tryCatch(
+              () =>
+                pluginMigrate.handler({
+                  databaseUrl,
+                  sql,
+                  migrationsDir: migrationsPath,
+                  projectDir: params.projectDir,
+                }),
+              PluginError.from(pluginMigrate.pluginName),
+            )
+          : runMigrations({ migrationsPath, sql });
+
         return pipe(
           TE.Do,
           TE.chainW(() => initDatabase(migrationSql, connectionOptions.database)),
-          TE.chainW(() => runMigrations({ migrationsPath, sql })),
+          TE.chainW(() => applyMigrations),
           TE.map(() => connectionPayload),
         );
       }
@@ -113,9 +140,11 @@ function workerHandler(params: CheckSQLWorkerParams): TE.TaskEither<WorkerError,
       return TE.right(connectionPayload);
     })
     .exhaustive();
+}
 
+function workerHandler(params: CheckSQLWorkerParams): TE.TaskEither<WorkerError, WorkerResult> {
   return pipe(
-    connnectionPayload,
+    resolveConnectionPayload(params),
     TE.chainW(({ sql, databaseUrl, pluginName }) => {
       return TE.tryCatch(
         () =>

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -144,47 +144,16 @@ async function generate(
     value: () => getDatabaseMetadata(sql),
   });
 
-  const typesMap = await getOrSetFromMapWithEnabled({
+  const typesMap = await resolveTypesMap({
+    overrides: params.overrides,
+    cache,
     shouldCache: cacheMetadata,
-    map: cache.overrides.types,
-    key: JSON.stringify(params.overrides?.types),
-    value: () => {
-      const map: TypesMap = new Map([["array", { override: false, value: "array" }]]);
-
-      for (const [key, value] of defaultTypesMap.entries()) {
-        map.set(key, { override: false, value });
-      }
-
-      for (const [k, v] of Object.entries(params.overrides?.types ?? {})) {
-        map.set(k, { override: true, value: typeof v === "string" ? v : v.return });
-      }
-
-      return map;
-    },
   });
 
-  const overridenColumnTypesMap = await getOrSetFromMapWithEnabled({
+  const overridenColumnTypesMap = await resolveColumnOverridesMap({
+    overrides: params.overrides,
+    cache,
     shouldCache: cacheMetadata,
-    map: cache.overrides.columns,
-    key: JSON.stringify(params.overrides?.columns),
-    value: () => {
-      const map: Map<string, Map<string, string>> = new Map();
-
-      for (const [colPath, type] of Object.entries(params.overrides?.columns ?? {})) {
-        const [table, column] = colPath.split(".");
-
-        if (table === undefined || column === undefined) {
-          throw new Error(`Invalid override column key: ${colPath}. Expected format: table.column`);
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        map.has(table)
-          ? map.get(table)?.set(column, type)
-          : map.set(table, new Map([[column, type]]));
-      }
-
-      return map;
-    },
   });
 
   const functionsMap = await getOrSetFromMapWithEnabled({
@@ -340,6 +309,61 @@ async function generate(
 
     throw e;
   }
+}
+
+function resolveTypesMap(params: {
+  overrides: GenerateParams["overrides"];
+  cache: Cache;
+  shouldCache: boolean;
+}): Promise<TypesMap> {
+  return getOrSetFromMapWithEnabled({
+    shouldCache: params.shouldCache,
+    map: params.cache.overrides.types,
+    key: JSON.stringify(params.overrides?.types),
+    value: () => {
+      const map: TypesMap = new Map([["array", { override: false, value: "array" }]]);
+
+      for (const [key, value] of defaultTypesMap.entries()) {
+        map.set(key, { override: false, value });
+      }
+
+      for (const [k, v] of Object.entries(params.overrides?.types ?? {})) {
+        map.set(k, { override: true, value: typeof v === "string" ? v : v.return });
+      }
+
+      return map;
+    },
+  });
+}
+
+function resolveColumnOverridesMap(params: {
+  overrides: GenerateParams["overrides"];
+  cache: Cache;
+  shouldCache: boolean;
+}): Promise<Map<string, Map<string, string>>> {
+  return getOrSetFromMapWithEnabled({
+    shouldCache: params.shouldCache,
+    map: params.cache.overrides.columns,
+    key: JSON.stringify(params.overrides?.columns),
+    value: () => {
+      const map: Map<string, Map<string, string>> = new Map();
+
+      for (const [colPath, type] of Object.entries(params.overrides?.columns ?? {})) {
+        const [table, column] = colPath.split(".");
+
+        if (table === undefined || column === undefined) {
+          throw new Error(`Invalid override column key: ${colPath}. Expected format: table.column`);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        map.has(table)
+          ? map.get(table)?.set(column, type)
+          : map.set(table, new Map([[column, type]]));
+      }
+
+      return map;
+    },
+  });
 }
 
 async function getDatabaseMetadata(sql: Sql) {
@@ -709,6 +733,7 @@ async function getPgCols(sql: Sql) {
           AND pg_class.relnamespace = pg_namespace.oid
           AND pg_attribute.attnum >= 1
       ORDER BY
+          pg_namespace.nspname,
           pg_class.relname,
           pg_attribute.attnum
   `;

--- a/packages/plugin-utils/src/plugin-test-driver.ts
+++ b/packages/plugin-utils/src/plugin-test-driver.ts
@@ -4,7 +4,7 @@ import path from "path";
 import parser from "@typescript-eslint/parser";
 import type ts from "typescript";
 import type { ParserServices, TSESTree } from "@typescript-eslint/utils";
-import type { SafeQLPlugin } from "./index";
+import { matchesQueryNodeSelector, type SafeQLPlugin } from "./index";
 
 export interface PluginTestDriverOptions {
   plugin: SafeQLPlugin;
@@ -77,7 +77,10 @@ export class PluginTestDriver {
     let taggedTemplate: TSESTree.TaggedTemplateExpression | undefined;
     if (this.plugin.onTarget) {
       for (const t of allTemplates) {
-        const result = this.plugin.onTarget({ node: t, context: { checker, parser: services } });
+        const result = this.plugin.onTarget({
+          node: t,
+          context: { checker, parser: services },
+        });
         if (result !== undefined && result !== false) {
           taggedTemplate = t;
         }
@@ -89,6 +92,54 @@ export class PluginTestDriver {
     }
 
     return { sql: this.buildSQL(taggedTemplate, checker, nodeMap) };
+  }
+
+  toBuilderSQL(source: string): ToSQLResult {
+    fs.writeFileSync(this.testFilePath, source);
+
+    const { ast, services } = parser.parseForESLint(source, {
+      filePath: this.testFilePath,
+      project: this.tsconfigPath,
+      loc: true,
+      range: true,
+      comment: false,
+      jsxPragma: null,
+    });
+
+    const checker = services.program?.getTypeChecker();
+    const nodeMap = services.esTreeNodeToTSNodeMap;
+
+    setParentPointers(ast);
+
+    if (!checker || !this.plugin.resolveQuery) {
+      return { skipped: true };
+    }
+
+    const calls = findAllCallExpressions(ast);
+    const terminal = calls.find((call) => this.isTerminalCallExpression(call));
+    if (!terminal) {
+      throw new Error("No terminal builder CallExpression found in source");
+    }
+
+    const tsNode = nodeMap.get(terminal);
+    const tsType = checker.getTypeAtLocation(tsNode);
+
+    const result = this.plugin.resolveQuery({
+      checker,
+      parser: services,
+      precedingSQL: "",
+      tsNode,
+      tsType,
+      tsTypeText: checker.typeToString(tsType),
+    });
+
+    return result === "skip" ? { skipped: true } : { sql: result.text };
+  }
+
+  private isTerminalCallExpression(node: TSESTree.CallExpression): boolean {
+    return (this.plugin.queryNodeKinds ?? []).some((selector) =>
+      matchesQueryNodeSelector(node, selector),
+    );
   }
 
   private buildSQL(
@@ -165,6 +216,18 @@ function findAllTaggedTemplates(node: TSESTree.Node): TSESTree.TaggedTemplateExp
   }
 
   forEachChild(node, (child) => results.push(...findAllTaggedTemplates(child)));
+
+  return results;
+}
+
+function findAllCallExpressions(node: TSESTree.Node): TSESTree.CallExpression[] {
+  const results: TSESTree.CallExpression[] = [];
+
+  if (node.type === "CallExpression") {
+    results.push(node);
+  }
+
+  forEachChild(node, (child) => results.push(...findAllCallExpressions(child)));
 
   return results;
 }


### PR DESCRIPTION
Stacked on #487.

Wires the plugin API into the `check-sql` lint rule so plugins drive validation:

- **Query-builder resolution** via `resolveQuery` — validate non-tag nodes (fluent builder `CallExpression`s) where the plugin produces the SQL itself (statically, or by compiling in its own sandbox).
- **Embedded raw-`sql` handling** via `onExpression`.
- **Plugin-provided migration runner** in the worker (`migrate` hook) — build the shadow database from a project's own migrations instead of the built-in `.sql` runner.

Engine-only — no specific ORM/driver plugin here; those stack on top.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * ESLint SQL linter now also supports linting terminal builder method calls (e.g., `db.execute(...)`) in addition to tagged templates.
  * Database initialization can now use a plugin-provided migrate resolver during first-time setup.

* **Improvements**
  * Expanded and unified type-checking and error reporting across supported SQL syntaxes, including improved handling of expected vs resolved types and reserved type comparisons.
  * More deterministic SQL generation metadata ordering.

* **Tests**
  * Added/expanded coverage for terminal call behavior, plugin query handling, and utility type resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->