### PR TITLE
feat(plugin-kysely): add Kysely plugin

### DIFF
--- a/.changeset/kysely-support.md
+++ b/.changeset/kysely-support.md
@@ -1,0 +1,21 @@
+---
+"@ts-safeql/plugin-kysely": minor
+"@ts-safeql/plugin-utils": minor
+"@ts-safeql/generate": minor
+"@ts-safeql/eslint-plugin": minor
+"@ts-safeql/connection-manager": patch
+---
+
+Add `@ts-safeql/plugin-kysely`, a first-class Kysely integration for SafeQL.
+
+The plugin validates Kysely raw `sql` templates and, when `kysely({ builder: true })` is enabled,
+raw SQL fragments inside Kysely query-builder chains. Pure Kysely builder queries stay covered by
+Kysely's own types; SafeQL focuses on the raw SQL it can reconstruct statically.
+
+Kysely TypeScript migrations can now build the shadow database used during validation, so SafeQL
+checks your queries against the schema your migrations actually produce — no separate database
+setup required.
+
+The shared plugin API now supports custom migration runners and non-template query resolution.
+Those hooks keep the ESLint rule generic while letting plugins teach SafeQL how each SQL library
+represents queries.

--- a/demos/plugin-kysely/eslint.config.js
+++ b/demos/plugin-kysely/eslint.config.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+import safeql from "@ts-safeql/eslint-plugin/config";
+import kysely from "@ts-safeql/plugin-kysely";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config({
+  files: ["src/**/*.ts"],
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      projectService: true,
+    },
+  },
+  extends: [
+    safeql.configs.connections({
+      // The Kysely plugin runs the TypeScript migrations in `migrations/`
+      // against a shadow database, then validates queries against it.
+      migrationsDir: "migrations",
+      // `builder: true` also lints the raw `sql` fragments embedded inside
+      // fluent builder chains (`.select(sql`...`.as())`, `.where(sql`...`)`).
+      plugins: [kysely({ builder: true })],
+      // CamelCasePlugin users: uncomment to map snake_case columns to camelCase.
+      // targets: [{ tag: "sql", fieldTransform: "camel" }],
+    }),
+  ],
+});

--- a/demos/plugin-kysely/migrations/0001_init.ts
+++ b/demos/plugin-kysely/migrations/0001_init.ts
@@ -1,0 +1,24 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("person")
+    .addColumn("id", "integer", (col) => col.primaryKey().generatedAlwaysAsIdentity())
+    .addColumn("first_name", "text", (col) => col.notNull())
+    .addColumn("email", "text", (col) => col.notNull())
+    .addColumn("bio", "text")
+    .execute();
+
+  await db.schema
+    .createTable("pet")
+    .addColumn("id", "integer", (col) => col.primaryKey().generatedAlwaysAsIdentity())
+    .addColumn("owner_id", "integer", (col) => col.notNull().references("person.id"))
+    .addColumn("name", "text", (col) => col.notNull())
+    .addColumn("species", "text", (col) => col.notNull())
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("pet").execute();
+  await db.schema.dropTable("person").execute();
+}

--- a/demos/plugin-kysely/package.json
+++ b/demos/plugin-kysely/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ts-safeql-demos/plugin-kysely",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src"
+  },
+  "devDependencies": {
+    "@eslint/js": "catalog:",
+    "@types/node": "catalog:",
+    "@types/pg": "^8.11.10",
+    "eslint": "catalog:",
+    "kysely": "^0.28.2",
+    "pg": "^8.13.1",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:"
+  },
+  "dependencies": {
+    "@ts-safeql/eslint-plugin": "workspace:*",
+    "@ts-safeql/plugin-kysely": "workspace:*"
+  }
+}

--- a/demos/plugin-kysely/src/builder.ts
+++ b/demos/plugin-kysely/src/builder.ts
@@ -1,0 +1,53 @@
+import { sql, type SqlBool } from "kysely";
+import { db } from "./db";
+
+/**
+ * Fluent builder chains with partial raw `sql` expressions embedded in them.
+ * SafeQL compiles the whole chain (through the fragments) and validates the
+ * embedded raw sql against the schema. Pure builder queries with no raw sql are
+ * left to Kysely's own types.
+ */
+
+// raw expression in a `.select(...)`
+export function builderSelectExpr() {
+  return db
+    .selectFrom("person")
+    .select(sql<string>`first_name || ' <' || email || '>'`.as("label"))
+    .execute();
+}
+
+// raw aggregate in a `.select(...)`
+export function builderAggregate() {
+  return db
+    .selectFrom("person")
+    .select(sql<number>`count(*)`.as("total"))
+    .execute();
+}
+
+// raw condition in a `.where(...)`, with a bound-parameter interpolation
+export function builderWhereExpr(minId: number) {
+  return db
+    .selectFrom("person")
+    .select("id")
+    .where(sql<SqlBool>`id > ${minId} and bio is not null`)
+    .execute();
+}
+
+// These embed invalid raw sql; the disables keep the demo green while proving
+// SafeQL flags them (verified via --report-unused-disable-directives).
+/* eslint-disable @ts-safeql/check-sql */
+
+// column "nonexistent" does not exist
+export const builderBadColumn = db
+  .selectFrom("person")
+  .select(sql<string>`upper(nonexistent)`.as("shout"))
+  .execute();
+
+// function "bogus_fn" does not exist
+export const builderBadFn = db
+  .selectFrom("person")
+  .select("id")
+  .where(sql<SqlBool>`bogus_fn(id)`)
+  .execute();
+
+/* eslint-enable @ts-safeql/check-sql */

--- a/demos/plugin-kysely/src/db.ts
+++ b/demos/plugin-kysely/src/db.ts
@@ -1,0 +1,22 @@
+import { Generated, Kysely, PostgresDialect } from "kysely";
+import { Pool } from "pg";
+
+// The Kysely schema for the demo, matching `migrations/0001_init.ts`.
+export interface Database {
+  person: {
+    id: Generated<number>;
+    first_name: string;
+    email: string;
+    bio: string | null;
+  };
+  pet: {
+    id: Generated<number>;
+    owner_id: number;
+    name: string;
+    species: string;
+  };
+}
+
+export const db = new Kysely<Database>({
+  dialect: new PostgresDialect({ pool: new Pool() }),
+});

--- a/demos/plugin-kysely/src/raw-sql.ts
+++ b/demos/plugin-kysely/src/raw-sql.ts
@@ -1,0 +1,61 @@
+import { sql } from "kysely";
+import { db } from "./db";
+
+/**
+ * Full raw `sql` queries with Kysely's `sql` expressions interpolated in. SafeQL
+ * validates the whole compiled query against the migrated schema.
+ */
+
+export function rawSelect() {
+  return sql<{ id: number; first_name: string }>`SELECT id, first_name FROM person`.execute(db);
+}
+
+export function rawNullable() {
+  return sql<{ bio: string | null }>`SELECT bio FROM person`.execute(db);
+}
+
+// sql.ref → quoted identifier
+export function rawRef() {
+  const column = "first_name";
+  return sql<{ first_name: string }>`SELECT ${sql.ref(column)} FROM person`.execute(db);
+}
+
+// sql.table → quoted table
+export function rawTable() {
+  return sql<{ email: string }>`SELECT email FROM ${sql.table("person")}`.execute(db);
+}
+
+// sql.lit → inlined literal; plain interpolation → bound parameter
+export function rawLitAndParam(id: number) {
+  return sql<{ email: string }>`
+    SELECT email FROM person WHERE id = ${id} AND first_name <> ${sql.lit("")}
+  `.execute(db);
+}
+
+// sql.join → expanded positional params
+export function rawIn(ids: number[]) {
+  if (ids.length === 0) {
+    return sql<{ id: number }>`SELECT id FROM person WHERE false`.execute(db);
+  }
+  return sql<{ id: number }>`SELECT id FROM person WHERE id IN (${sql.join(ids)})`.execute(db);
+}
+
+export function rawJoin() {
+  return sql<{ first_name: string; name: string }>`
+    SELECT person.first_name, pet.name
+    FROM person
+    JOIN pet ON pet.owner_id = person.id
+  `.execute(db);
+}
+
+export function rawInsert(firstName: string, email: string) {
+  return sql<{ id: number }>`
+    INSERT INTO person (first_name, email) VALUES (${firstName}, ${email}) RETURNING id
+  `.execute(db);
+}
+
+// eslint-disable-next-line @ts-safeql/check-sql -- column "nope" does not exist
+export const rawBadColumn = sql<{ x: number }>`SELECT nope FROM person`.execute(db);
+
+// eslint-disable-next-line @ts-safeql/check-sql -- id is a number, not a string
+export const rawWrongType = sql<{ id: string }>`SELECT id FROM person`.execute(db);

--- a/demos/plugin-kysely/tsconfig.json
+++ b/demos/plugin-kysely/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
           { text: "Postgres.js", link: "/compatibility/postgres.js.html" },
           { text: "@vercel/postgres", link: "/compatibility/vercel" },
           { text: "slonik", link: "/compatibility/slonik" },
+          { text: "Kysely", link: "/compatibility/kysely" },
           { text: "node-postgres (pg)", link: "/compatibility/node-postgres" },
           { text: "Sequelize", link: "/compatibility/sequelize" },
         ],

--- a/docs/compatibility/kysely.md
+++ b/docs/compatibility/kysely.md
@@ -1,0 +1,201 @@
+---
+layout: doc
+---
+
+# SafeQL :heart: Kysely
+
+SafeQL is compatible with [Kysely](https://kysely.dev). It validates Kysely's
+[`sql` template tag](https://kysely.dev/docs/recipes/raw-sql) against your real database, and
+can build the shadow database directly from your Kysely (TypeScript) migrations.
+
+::: warning EXPERIMENTAL
+The Kysely plugin is experimental and may change in future releases.
+:::
+
+## Scope
+
+SafeQL validates the **raw SQL** in your Kysely code, in two forms:
+
+- **Default mode:** standalone raw `sql` tags (`` sql<T>`...` ``), including the Kysely `sql`
+  expressions interpolated inside them (`sql.ref`, `sql.val`, `sql.lit`, `sql.join`, …).
+- **Builder mode (`builder: true`):** the **partial raw `sql` fragments embedded in a fluent
+  builder chain** — ``.select(sql`...`.as("x"))``, ``.where(sql`...`)``. SafeQL compiles the
+  whole chain through those fragments and validates the resulting SQL against the database.
+
+A _pure_ builder query (no raw `sql`) is left to Kysely's own types — SafeQL doesn't re-check it.
+
+## Installation
+
+```bash
+npm install -D @ts-safeql/plugin-kysely
+```
+
+The plugin uses your project's `kysely`. Running TypeScript migrations (`migrationsDir`)
+additionally needs `pg` and `tsx` installed in your project — they're declared as optional peer
+dependencies and only loaded when migrations run.
+
+## Using the Kysely Plugin
+
+```js
+// eslint.config.js
+import safeql from "@ts-safeql/eslint-plugin/config";
+import kysely from "@ts-safeql/plugin-kysely";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  // ...
+  safeql.configs.connections({
+    databaseUrl: "postgres://user:pass@localhost:5432/db",
+    plugins: [kysely()],
+  }),
+);
+```
+
+The plugin decides on its own which `sql` tags are real queries. Only standalone queries are
+validated; fragments (see below) are skipped.
+
+```typescript
+import { sql } from "kysely";
+
+// Validated against the database; the result row type is checked against <T>.
+const rows = await sql<{ id: number; name: string }>`SELECT id, name FROM person`.execute(db);
+
+// Wrong type → reported (and auto-fixed with `--fix`)
+const bad = await sql<{ id: string }>`SELECT id FROM person`.execute(db);
+//                       ~~~~~~~~~~
+// Error: Incorrect type annotation. Expected: { id: number }
+```
+
+## Builder mode — linting embedded raw `sql` (opt-in)
+
+Enable `builder: true` to also lint the raw `sql` fragments you embed inside fluent builder
+chains. SafeQL compiles the whole chain (through the fragments) and validates the resulting SQL.
+
+```js
+// eslint.config.js
+import safeql from "@ts-safeql/eslint-plugin/config";
+import kysely from "@ts-safeql/plugin-kysely";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  // ...
+  safeql.configs.connections({
+    databaseUrl: "postgres://user:pass@localhost:5432/db",
+    plugins: [kysely({ builder: true })],
+  }),
+);
+```
+
+```typescript
+import { sql, type SqlBool } from "kysely";
+
+// The embedded raw sql is validated against the schema:
+db.selectFrom("person")
+  .select(sql<string>`upper(first_name)`.as("shout"))
+  .execute();
+db.selectFrom("person")
+  .select("id")
+  .where(sql<SqlBool>`bio is not null`)
+  .execute();
+
+// Caught — the embedded raw sql references a column that doesn't exist:
+db.selectFrom("person")
+  .select(sql<string>`upper(nonexistent)`.as("x"))
+  .execute();
+//                                          ~~~~~~~~~~~~~~~~~~~ column "nonexistent" does not exist
+
+// A pure builder query (no raw sql) is left to Kysely's own types — not re-checked here.
+db.selectFrom("person").select("id").execute();
+```
+
+Chains whose embedded sql isn't statically reconstructible (a dynamic identifier via
+`sql.ref(someVar)`, a `select((eb) => …)` callback, a runtime-built fragment) are skipped rather
+than guessed. Runtime values interpolated into a fragment (`` sql`id > ${x}` ``) are validated as
+bound parameters.
+
+The builder is recognized by its **type** — any `Kysely` or `Transaction` value, under any name
+(`db`, `client`, a `trx` callback parameter, a `this.db` field). A root whose type SafeQL can't
+see (e.g. an `any`-typed instance) is skipped rather than guessed.
+
+## Building the database from Kysely migrations
+
+Instead of pointing SafeQL at a live database, you can let it build a throwaway **shadow
+database** from your Kysely migrations. The plugin runs your TypeScript migration files (via
+[`Migrator`](https://kysely.dev/docs/migrations)) before validating queries:
+
+```js
+// eslint.config.js
+import safeql from "@ts-safeql/eslint-plugin/config";
+import kysely from "@ts-safeql/plugin-kysely";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  // ...
+  safeql.configs.connections({
+    migrationsDir: "migrations", // your Kysely migration files (up/down)
+    plugins: [kysely()],
+  }),
+);
+```
+
+```typescript
+// migrations/0001_init.ts
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("person")
+    .addColumn("id", "integer", (col) => col.primaryKey().generatedAlwaysAsIdentity())
+    .addColumn("name", "text", (col) => col.notNull())
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("person").execute();
+}
+```
+
+Migrations run in alpha-numeric filename order. TypeScript migration files are loaded directly —
+no build step required.
+
+## CamelCasePlugin
+
+If you use Kysely's `CamelCasePlugin` (camelCase in TypeScript, snake_case in the database), tell
+SafeQL to camelCase the inferred column names with a `fieldTransform` target:
+
+```js
+safeql.configs.connections({
+  databaseUrl: "postgres://user:pass@localhost:5432/db",
+  plugins: [kysely()],
+  targets: [{ tag: "sql", fieldTransform: "camel" }],
+});
+```
+
+```typescript
+// first_name (DB) → firstName (TypeScript)
+const rows = await sql<{ firstName: string }>`SELECT first_name FROM person`.execute(db);
+```
+
+## Generating the `Database` interface
+
+SafeQL checks the `<T>` you write against the real result; it doesn't generate Kysely's
+`Database` type. To keep that type in sync with your schema, use
+[kysely-codegen](https://github.com/RobinBlomberg/kysely-codegen) or another generator from
+[Kysely's "Generating types" docs](https://kysely.dev/docs/generating-types).
+
+## Support Matrix
+
+Legend: `✅` supported, `⚠️` partial support, `❌` unsupported, `➖` not applicable.
+
+| Library syntax                                                             | Support | Notes                                                                                          |
+| -------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `` sql<T>`...` `` (standalone / `.execute()` / `.compile()`)               | ✅      | Validated as a query; row type checked against `<T>`                                           |
+| `sql.val(...)` / plain `${value}`                                          | ✅      | Bound parameter                                                                                |
+| `sql.ref(...)`, `sql.id(...)`, `sql.table(...)`                            | ✅      | Inlined as quoted identifiers (static values only)                                             |
+| `sql.lit(...)`                                                             | ✅      | Inlined as a SQL literal                                                                       |
+| `sql.raw(...)`                                                             | ⚠️      | Inlined when the argument is a static string; otherwise the query is skipped                   |
+| `sql.join([...])`                                                          | ✅      | Expanded to positional placeholders (static arrays)                                            |
+| Nested/embedded `` sql`...` `` fragments                                   | ✅      | Inlined into the outer query                                                                   |
+| ``sql`...`.as("alias")`` (selection fragment)                              | ⚠️      | Intentionally skipped — not a standalone query                                                 |
+| Raw `sql` embedded in a builder (`.select(sql`…`.as())`, `.where(sql`…`)`) | ⚠️      | Opt-in with `builder: true`; the chain is compiled through its fragments and the SQL validated |
+| Pure fluent builder (no raw `sql`)                                         | ➖      | Not re-checked — left to Kysely's own types                                                    |

--- a/packages/plugins/kysely/build.config.ts
+++ b/packages/plugins/kysely/build.config.ts
@@ -1,0 +1,21 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig([
+  {
+    entries: ["src/index"],
+    declaration: true,
+    sourcemap: true,
+    rollup: {
+      emitCJS: true,
+    },
+    externals: [
+      "@ts-safeql/plugin-utils",
+      "@typescript-eslint/utils",
+      "kysely",
+      "pg",
+      "postgres",
+      "tsx",
+      "typescript",
+    ],
+  },
+]);

--- a/packages/plugins/kysely/package.json
+++ b/packages/plugins/kysely/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@ts-safeql/plugin-kysely",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ts-safeql/safeql.git",
+    "directory": "packages/plugins/kysely"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "type": "module",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.mjs",
+  "main": "dist/index.cjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "unbuild",
+    "dev": "unbuild --stub",
+    "typecheck": "tsc -b",
+    "test": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@ts-safeql/eslint-plugin": "workspace:*",
+    "@ts-safeql/plugin-utils": "workspace:*",
+    "@ts-safeql/test-utils": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/pg": "^8.11.10",
+    "@typescript-eslint/parser": "catalog:",
+    "@typescript-eslint/rule-tester": "catalog:",
+    "@typescript-eslint/utils": "catalog:",
+    "kysely": "^0.28.2",
+    "pg": "^8.13.1",
+    "postgres": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "unbuild": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "kysely": ">=0.27.0",
+    "pg": ">=8.0.0",
+    "tsx": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "pg": {
+      "optional": true
+    },
+    "tsx": {
+      "optional": true
+    }
+  }
+}

--- a/packages/plugins/kysely/src/__fixtures__/migrations/0001_create_person.ts
+++ b/packages/plugins/kysely/src/__fixtures__/migrations/0001_create_person.ts
@@ -1,0 +1,14 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("person")
+    .addColumn("id", "integer", (col) => col.primaryKey().generatedAlwaysAsIdentity())
+    .addColumn("name", "text", (col) => col.notNull())
+    .addColumn("bio", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("person").execute();
+}

--- a/packages/plugins/kysely/src/index.ts
+++ b/packages/plugins/kysely/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./plugin";

--- a/packages/plugins/kysely/src/migrate.test.ts
+++ b/packages/plugins/kysely/src/migrate.test.ts
@@ -1,0 +1,52 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { TsxFileMigrationProvider } from "./migrate";
+
+describe("TsxFileMigrationProvider", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "safeql-kysely-mig-"));
+
+    // Intentionally written out of order to prove alpha-numeric sorting.
+    fs.writeFileSync(
+      path.join(dir, "0002_second.ts"),
+      "export async function up() {}\nexport async function down() {}\n",
+    );
+    fs.writeFileSync(
+      path.join(dir, "0001_first.ts"),
+      "export async function up() {}\nexport async function down() {}\n",
+    );
+    fs.writeFileSync(path.join(dir, "types.d.ts"), "export type X = number;\n");
+    fs.writeFileSync(path.join(dir, "README.md"), "# not a migration\n");
+  });
+
+  afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("reads migrations in alpha-numeric order, ignoring non-migration files", async () => {
+    const provider = new TsxFileMigrationProvider(dir);
+    const migrations = await provider.getMigrations();
+
+    expect(Object.keys(migrations)).toEqual(["0001_first", "0002_second"]);
+  });
+
+  it("loads `up`/`down` as callable functions", async () => {
+    const provider = new TsxFileMigrationProvider(dir);
+    const migrations = await provider.getMigrations();
+
+    expect(typeof migrations["0001_first"].up).toBe("function");
+    expect(typeof migrations["0001_first"].down).toBe("function");
+  });
+
+  it("returns an empty set for a directory with no migrations", async () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "safeql-kysely-empty-"));
+    try {
+      const provider = new TsxFileMigrationProvider(empty);
+      expect(await provider.getMigrations()).toEqual({});
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/plugins/kysely/src/migrate.ts
+++ b/packages/plugins/kysely/src/migrate.ts
@@ -1,0 +1,132 @@
+import { createRequire } from "module";
+import fs from "fs";
+import path from "path";
+import type { MigrateContext } from "@ts-safeql/plugin-utils";
+import type { Migration, MigrationProvider } from "kysely";
+
+const MIGRATION_FILE = /\.(?:m|c)?[jt]s$/;
+const DECLARATION_FILE = /\.d\.(?:m|c)?ts$/;
+
+// Loads migration files via `tsx` so TS migrations run in the worker; Kysely's built-in provider uses
+// `import()`, which can't load `.ts` at runtime.
+export class TsxFileMigrationProvider implements MigrationProvider {
+  constructor(private readonly migrationFolder: string) {}
+
+  async getMigrations(): Promise<Record<string, Migration>> {
+    // Absolute path: `tsx.require` needs one and the folder may arrive relative.
+    const folder = path.resolve(this.migrationFolder);
+
+    if (!fs.existsSync(folder)) {
+      return {};
+    }
+
+    const files = fs
+      .readdirSync(folder)
+      .filter((file) => MIGRATION_FILE.test(file) && !DECLARATION_FILE.test(file))
+      .sort();
+
+    const migrations: Record<string, Migration> = {};
+
+    for (const file of files) {
+      const fullPath = path.join(folder, file);
+      const name = file.replace(MIGRATION_FILE, "");
+      if (name in migrations) {
+        throw new Error(
+          `Duplicate Kysely migration name "${name}" (e.g. two files differing only by extension). Migration names must be unique.`,
+        );
+      }
+      const mod = loadModule(fullPath);
+      migrations[name] = { up: mod.up, down: mod.down };
+    }
+
+    return migrations;
+  }
+}
+
+interface MigrationModule {
+  up: Migration["up"];
+  down?: Migration["down"];
+}
+
+function loadModule(absolutePath: string): MigrationModule {
+  const tsx = loadTsx();
+  const mod = tsx.require(absolutePath, import.meta.url);
+  const resolved = (mod as { default?: unknown }).default ?? mod;
+
+  if (
+    typeof resolved !== "object" ||
+    resolved === null ||
+    typeof (resolved as { up?: unknown }).up !== "function" ||
+    ((resolved as { down?: unknown }).down !== undefined &&
+      typeof (resolved as { down?: unknown }).down !== "function")
+  ) {
+    throw new Error(
+      `Kysely migration "${absolutePath}" must export an \`up\` function (\`down\` is optional).`,
+    );
+  }
+
+  return resolved as MigrationModule;
+}
+
+function loadTsx(): { require: (id: string, fromFile: string) => unknown } {
+  try {
+    return createRequire(import.meta.url)("tsx/cjs/api") as {
+      require: (id: string, fromFile: string) => unknown;
+    };
+  } catch (cause) {
+    throw new Error(
+      'SafeQL could not load "tsx", which is required to run Kysely TypeScript migrations. ' +
+        "Install it in your project (e.g. `npm i -D tsx`).",
+      { cause },
+    );
+  }
+}
+
+export async function migrate({ databaseUrl, migrationsDir }: MigrateContext): Promise<void> {
+  const { Kysely, Migrator, PostgresDialect } = await loadKysely();
+  const { Pool } = await loadPg();
+
+  // SafeQL owns the pool, so SafeQL ends it: `finally` runs even if the Kysely constructor throws.
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    const db = new Kysely<unknown>({ dialect: new PostgresDialect({ pool }) });
+    const migrator = new Migrator({
+      db,
+      provider: new TsxFileMigrationProvider(migrationsDir),
+    });
+
+    const { error, results } = await migrator.migrateToLatest();
+
+    if (error !== undefined) {
+      const failed = results?.find((result) => result.status === "Error");
+      const where = failed ? ` (in "${failed.migrationName}")` : "";
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(`Kysely migration failed${where}: ${reason}`);
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+async function loadKysely(): Promise<typeof import("kysely")> {
+  try {
+    return await import("kysely");
+  } catch (cause) {
+    throw new Error(
+      'SafeQL could not load "kysely". Install it in your project to run Kysely migrations.',
+      { cause },
+    );
+  }
+}
+
+async function loadPg(): Promise<typeof import("pg")> {
+  try {
+    return await import("pg");
+  } catch (cause) {
+    throw new Error(
+      'SafeQL could not load "pg". Install it in your project to run Kysely migrations.',
+      { cause },
+    );
+  }
+}

--- a/packages/plugins/kysely/src/plugin.builder.test.ts
+++ b/packages/plugins/kysely/src/plugin.builder.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { PluginTestDriver, type ToSQLResult } from "@ts-safeql/plugin-utils/testing";
+import plugin from "./plugin";
+
+const driver = new PluginTestDriver({
+  plugin: plugin.factory({ builder: true }),
+  projectDir: process.cwd(),
+});
+
+afterAll(() => driver.teardown());
+
+const preamble = `
+import { Kysely, sql } from "kysely";
+interface DB { person: { id: number; first_name: string; bio: string | null } }
+declare const db: Kysely<DB>;
+declare const min: number;
+declare const col: string;
+`;
+
+type Case = { name: string; code: string; output: ToSQLResult };
+
+const validCases: Case[] = [
+  {
+    name: "embedded raw sql in .select(.as())",
+    code: `db.selectFrom("person").select(sql<string>\`upper(first_name)\`.as("shout")).execute()`,
+    output: { sql: `select upper(first_name) as "shout" from "person"` },
+  },
+  {
+    name: "embedded raw sql in .where()",
+    code: `db.selectFrom("person").select("id").where(sql\`bio is not null\`).execute()`,
+    output: { sql: `select "id" from "person" where bio is not null` },
+  },
+  {
+    name: "embedded raw sql alongside a static column",
+    code: `db.selectFrom("person").select(["id", sql<string>\`lower(first_name)\`.as("lo")]).execute()`,
+    output: { sql: `select "id", lower(first_name) as "lo" from "person"` },
+  },
+  {
+    name: "value interpolation in embedded sql becomes a bound param",
+    code: `db.selectFrom("person").select("id").where(sql\`id > \${min}\`).execute()`,
+    output: { sql: `select "id" from "person" where id > $1` },
+  },
+  {
+    name: "sql.ref helper in embedded sql is honored",
+    code: `db.selectFrom("person").select(sql\`\${sql.ref("first_name")}\`.as("n")).execute()`,
+    output: { sql: `select "first_name" as "n" from "person"` },
+  },
+];
+
+const skipCases: Case[] = [
+  {
+    name: "pure builder (no embedded raw sql) is left to Kysely's types",
+    code: `db.selectFrom("person").select(["id", "first_name"]).execute()`,
+    output: { skipped: true },
+  },
+  {
+    name: "dynamic identifier in embedded sql is skipped",
+    code: `db.selectFrom("person").select(sql\`\${sql.ref(col)}\`.as("x")).execute()`,
+    output: { skipped: true },
+  },
+  {
+    name: "dynamic select callback is skipped",
+    code: `db.selectFrom("person").select((eb) => eb.fn.countAll().as("n")).execute()`,
+    output: { skipped: true },
+  },
+];
+
+describe("kysely plugin — builder embedded-sql (valid)", () => {
+  for (const c of validCases) {
+    it(c.name, () => expect(driver.toBuilderSQL(preamble + c.code)).toEqual(c.output));
+  }
+});
+
+describe("kysely plugin — builder embedded-sql (skip)", () => {
+  for (const c of skipCases) {
+    it(c.name, () => expect(driver.toBuilderSQL(preamble + c.code)).toEqual(c.output));
+  }
+});
+
+const rootCases: { name: string; source: string; output: ToSQLResult }[] = [
+  {
+    name: "root under a non-conventional name (client) is detected by type",
+    source: `
+import { Kysely, sql } from "kysely";
+interface DB { person: { id: number; first_name: string } }
+declare const client: Kysely<DB>;
+client.selectFrom("person").select(sql<string>\`upper(first_name)\`.as("x")).execute()`,
+    output: { sql: `select upper(first_name) as "x" from "person"` },
+  },
+  {
+    name: "a Kysely method prefix (withSchema) is preserved, not mistaken for the root",
+    source: `
+import { Kysely, sql } from "kysely";
+interface DB { person: { id: number; first_name: string } }
+declare const db: Kysely<DB>;
+db.withSchema("audit").selectFrom("person").select(sql<string>\`upper(first_name)\`.as("x")).execute()`,
+    output: { sql: `select upper(first_name) as "x" from "audit"."person"` },
+  },
+  {
+    name: "an any-typed root is skipped (never false-validated)",
+    source: `
+import { sql } from "kysely";
+declare const db: any;
+db.selectFrom("person").select(sql<string>\`upper(first_name)\`.as("x")).execute()`,
+    output: { skipped: true },
+  },
+];
+
+describe("kysely plugin — builder root detection by type", () => {
+  for (const c of rootCases) {
+    it(c.name, () => expect(driver.toBuilderSQL(c.source)).toEqual(c.output));
+  }
+});

--- a/packages/plugins/kysely/src/plugin.integration.test.ts
+++ b/packages/plugins/kysely/src/plugin.integration.test.ts
@@ -1,0 +1,275 @@
+import { generateTestDatabaseName, setupTestDatabase } from "@ts-safeql/test-utils";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import parser from "@typescript-eslint/parser";
+import path from "path";
+import postgres, { Sql } from "postgres";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { rules } from "@ts-safeql/eslint-plugin";
+import type { PluginDescriptor } from "@ts-safeql/plugin-utils";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.afterAll = afterAll;
+
+const POSTGRES_URL = "postgres://postgres:postgres@localhost:5432/postgres";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      projectService: true,
+      tsconfigRootDir: path.resolve(__dirname, "./ts-fixture"),
+    },
+  },
+});
+
+const kyselyPlugin = {
+  package: "@ts-safeql/plugin-kysely",
+  config: {},
+} satisfies PluginDescriptor;
+
+const k = (code: string) =>
+  `import { sql, Kysely } from "kysely"; declare const db: Kysely<any>; ${code}`;
+
+const withBuilderConnection = (databaseName: string, overrides?: Record<string, unknown>) => [
+  {
+    connections: [
+      {
+        databaseUrl: `postgres://postgres:postgres@localhost:5432/${databaseName}`,
+        plugins: [{ ...kyselyPlugin, config: { builder: true } }],
+        keepAlive: false,
+        ...overrides,
+      },
+    ],
+  },
+];
+
+RuleTester.describe("kysely integration — sql tag", () => {
+  const databaseName = generateTestDatabaseName();
+  let sql!: Sql;
+  let dropFn!: () => Promise<unknown>;
+
+  beforeAll(async () => {
+    const testDatabase = await setupTestDatabase({ databaseName, postgresUrl: POSTGRES_URL });
+    dropFn = testDatabase.drop;
+    sql = testDatabase.sql;
+
+    await sql.unsafe(`
+      CREATE TABLE person (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        first_name TEXT NOT NULL,
+        name TEXT NOT NULL,
+        bio TEXT
+      );
+    `);
+  });
+
+  RuleTester.afterAll(async () => {
+    await sql.end();
+    await dropFn();
+  });
+
+  const withConnection = (overrides?: Record<string, unknown>) => [
+    {
+      connections: [
+        {
+          databaseUrl: `postgres://postgres:postgres@localhost:5432/${databaseName}`,
+          plugins: [kyselyPlugin],
+          keepAlive: false,
+          ...overrides,
+        },
+      ],
+    },
+  ];
+
+  ruleTester.run("check-sql", rules["check-sql"], {
+    valid: [
+      {
+        name: "correct row type",
+        options: withConnection(),
+        code: k("sql<{ id: number; name: string }>`SELECT id, name FROM person`"),
+      },
+      {
+        name: "nullable column",
+        options: withConnection(),
+        code: k("sql<{ bio: string | null }>`SELECT bio FROM person`"),
+      },
+      {
+        name: "executed query",
+        options: withConnection(),
+        code: k("sql<{ id: number }>`SELECT id FROM person`.execute(db)"),
+      },
+      {
+        // CamelCasePlugin users: snake_case columns map to camelCase via a
+        // `fieldTransform: "camel"` target (the plugin keeps onTarget authority).
+        name: "camelCase field transform",
+        options: withConnection({ targets: [{ tag: "sql", fieldTransform: "camel" }] }),
+        code: k("sql<{ firstName: string }>`SELECT first_name FROM person`"),
+      },
+    ],
+    invalid: [
+      {
+        name: "nonexistent column",
+        options: withConnection(),
+        code: k("sql<{ id: number }>`SELECT nonexistent FROM person`"),
+        errors: [{ messageId: "invalidQuery" }],
+      },
+      {
+        name: "wrong column type",
+        options: withConnection(),
+        code: k("sql<{ id: string }>`SELECT id FROM person`"),
+        output: k("sql<{ id: number }>`SELECT id FROM person`"),
+        errors: [{ messageId: "incorrectTypeAnnotations" }],
+      },
+    ],
+  });
+});
+
+RuleTester.describe("kysely integration — migrations", () => {
+  // Sanitize to lowercase `[a-z0-9_]`: SafeQL's `CREATE DATABASE` is unquoted,
+  // so a `-` (which nanoid may emit) or uppercase would break it.
+  const databaseName = generateTestDatabaseName()
+    .replace(/[^a-z0-9_]/gi, "_")
+    .toLowerCase();
+
+  RuleTester.afterAll(async () => {
+    const root = postgres(POSTGRES_URL);
+    try {
+      await root.unsafe(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+    } finally {
+      await root.end();
+    }
+  });
+
+  const withMigrations = () => [
+    {
+      connections: [
+        {
+          migrationsDir: "src/__fixtures__/migrations",
+          connectionUrl: POSTGRES_URL,
+          databaseName,
+          watchMode: false,
+          plugins: [kyselyPlugin],
+          keepAlive: false,
+        },
+      ],
+    },
+  ];
+
+  ruleTester.run("check-sql", rules["check-sql"], {
+    valid: [
+      {
+        name: "query against migrated schema",
+        options: withMigrations(),
+        code: k("sql<{ id: number; name: string }>`SELECT id, name FROM person`"),
+      },
+    ],
+    invalid: [
+      {
+        name: "column missing from migrated schema",
+        options: withMigrations(),
+        code: k("sql<{ id: number }>`SELECT nonexistent FROM person`"),
+        errors: [{ messageId: "invalidQuery" }],
+      },
+    ],
+  });
+});
+
+RuleTester.describe("kysely integration — builder embedded sql (opt-in)", () => {
+  const databaseName = generateTestDatabaseName();
+  let sql!: Sql;
+  let dropFn!: () => Promise<unknown>;
+
+  beforeAll(async () => {
+    const testDatabase = await setupTestDatabase({ databaseName, postgresUrl: POSTGRES_URL });
+    dropFn = testDatabase.drop;
+    sql = testDatabase.sql;
+
+    await sql.unsafe(`
+      CREATE TABLE person (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        first_name TEXT NOT NULL,
+        name TEXT NOT NULL,
+        bio TEXT
+      );
+    `);
+  });
+
+  RuleTester.afterAll(async () => {
+    await sql.end();
+    await dropFn();
+  });
+
+  // Builder mode compiles the whole chain — including its embedded `sql`
+  // fragments — and validates the resulting SQL against the database. A pure
+  // builder (no raw sql) is left to Kysely's own types.
+  const kSql = (code: string) =>
+    `import { Kysely, sql, type SqlBool } from "kysely";
+interface DB { person: { id: number; first_name: string; name: string; bio: string | null } }
+declare const db: Kysely<DB>;
+${code}`;
+
+  ruleTester.run("check-sql", rules["check-sql"], {
+    valid: [
+      {
+        name: "embedded raw sql in .select(.as()) is validated",
+        options: withBuilderConnection(databaseName),
+        code: kSql(
+          `db.selectFrom("person").select(sql<string>\`upper(first_name)\`.as("shout")).execute();`,
+        ),
+      },
+      {
+        name: "embedded raw sql in .where() is validated",
+        options: withBuilderConnection(databaseName),
+        code: kSql(`db.selectFrom("person").select("id").where(sql\`bio is not null\`).execute();`),
+      },
+      {
+        name: "value interpolation in embedded sql is a bound param",
+        options: withBuilderConnection(databaseName),
+        code: kSql(
+          `declare const min: number;
+db.selectFrom("person").select("id").where(sql\`id > \${min}\`).execute();`,
+        ),
+      },
+      {
+        name: "pure builder (no embedded raw sql) is left to Kysely's types",
+        options: withBuilderConnection(databaseName),
+        code: kSql(`db.selectFrom("person").select(["id", "first_name"]).execute();`),
+      },
+      {
+        name: "dynamic identifier in embedded sql is skipped",
+        options: withBuilderConnection(databaseName),
+        code: kSql(
+          `declare const col: string;
+db.selectFrom("person").select(sql\`\${sql.ref(col)}\`.as("x")).execute();`,
+        ),
+      },
+      {
+        name: "dynamic select callback is skipped",
+        options: withBuilderConnection(databaseName),
+        code: kSql(`db.selectFrom("person").select((eb) => eb.fn.countAll().as("n")).execute();`),
+      },
+    ],
+    invalid: [
+      {
+        name: "nonexistent column in embedded sql is detected (squiggle on the fragment)",
+        options: withBuilderConnection(databaseName),
+        code: kSql(
+          `db.selectFrom("person").select(sql<string>\`upper(nonexistent)\`.as("x")).execute();`,
+        ),
+        // The error must land on the embedded `sql` fragment, not a misplaced
+        // offset in the compiled SQL.
+        errors: [{ messageId: "invalidQuery", line: 4, column: 32 }],
+      },
+      {
+        name: "invalid function in embedded sql is detected (squiggle on the fragment)",
+        options: withBuilderConnection(databaseName),
+        code: kSql(
+          `db.selectFrom("person").select("id").where(sql<SqlBool>\`bogus_fn(id)\`).execute();`,
+        ),
+        errors: [{ messageId: "invalidQuery", line: 4, column: 44 }],
+      },
+    ],
+  });
+});

--- a/packages/plugins/kysely/src/plugin.test.ts
+++ b/packages/plugins/kysely/src/plugin.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { PluginTestDriver, type ToSQLResult } from "@ts-safeql/plugin-utils/testing";
+import plugin from "./plugin";
+
+const driver = new PluginTestDriver({
+  plugin: plugin.factory({}),
+  projectDir: process.cwd(),
+});
+
+afterAll(() => driver.teardown());
+
+type Case = {
+  name: string;
+  source: string;
+  output: ToSQLResult;
+};
+
+const imp = (code: string) =>
+  `import { sql, Kysely } from "kysely"; declare const db: Kysely<any>; ${code}`;
+
+const targetCases: Case[] = [
+  {
+    name: "bare sql tag is validated",
+    source: imp("sql`select 1`"),
+    output: { sql: "select 1" },
+  },
+  {
+    name: "typed sql tag is validated",
+    source: imp("sql<{ id: number }>`select 1 as id`"),
+    output: { sql: "select 1 as id" },
+  },
+  {
+    name: "executed sql tag is validated",
+    source: imp("sql`select 1`.execute(db)"),
+    output: { sql: "select 1" },
+  },
+  {
+    name: "compiled sql tag is validated",
+    source: imp("sql`select 1`.compile(db)"),
+    output: { sql: "select 1" },
+  },
+  {
+    name: "a sql tag NOT imported from kysely is ignored",
+    source: "const sql = (s: TemplateStringsArray) => s; sql`select 1`",
+    output: { skipped: true },
+  },
+  {
+    name: ".as() selection fragment is skipped",
+    source: imp("db.selectFrom('person').select(sql<string>`first_name`.as('n'))"),
+    output: { skipped: true },
+  },
+  {
+    name: "sql tag passed as a call argument (builder fragment) is skipped",
+    source: imp("declare function take(x: unknown): void; take(sql`now()`)"),
+    output: { skipped: true },
+  },
+  {
+    name: "nested fragment inside another sql template is skipped on its own",
+    source: imp("sql`select * from person where ${sql`id = ${1}`}`"),
+    output: { sql: "select * from person where id = $N" },
+  },
+];
+
+const expressionCases: Case[] = [
+  {
+    name: "plain interpolation -> positional param",
+    source: imp("const id = 123; sql`select * from person where id = ${id}`"),
+    output: { sql: "select * from person where id = $1" },
+  },
+  {
+    name: "sql.val -> positional param",
+    source: imp("sql`select ${sql.val(42)} as answer`"),
+    output: { sql: "select $N as answer" },
+  },
+  {
+    name: "sql.ref -> quoted identifier",
+    source: imp("sql`select ${sql.ref('first_name')} from person`"),
+    output: { sql: 'select "first_name" from person' },
+  },
+  {
+    name: "sql.ref dotted -> qualified quoted identifier",
+    source: imp("sql`select ${sql.ref('person.first_name')} from person`"),
+    output: { sql: 'select "person"."first_name" from person' },
+  },
+  {
+    name: "sql.ref with resolvable const -> quoted identifier",
+    source: imp("const col = 'first_name'; sql`select ${sql.ref(col)} from person`"),
+    output: { sql: 'select "first_name" from person' },
+  },
+  {
+    name: "sql.ref with dynamic value -> skip query",
+    source: imp("declare const col: string; sql`select ${sql.ref(col)} from person`"),
+    output: { sql: "select /* skipped */ from person" },
+  },
+  {
+    name: "sql.id -> dot-joined quoted identifiers",
+    source: imp("sql`create index ${sql.id('person', 'name_idx')} on person`"),
+    output: { sql: 'create index "person"."name_idx" on person' },
+  },
+  {
+    name: "sql.table -> quoted table",
+    source: imp("sql`select name from ${sql.table('person')}`"),
+    output: { sql: 'select name from "person"' },
+  },
+  {
+    name: "sql.table schema-qualified -> qualified quoted table",
+    source: imp("sql`select name from ${sql.table('public.person')}`"),
+    output: { sql: 'select name from "public"."person"' },
+  },
+  {
+    name: "sql.lit string -> embedded literal",
+    source: imp("sql`select * from person where status = ${sql.lit('active')}`"),
+    output: { sql: "select * from person where status = 'active'" },
+  },
+  {
+    name: "sql.lit number -> embedded literal",
+    source: imp("sql`select ${sql.lit(42)}`"),
+    output: { sql: "select 42" },
+  },
+  {
+    name: "sql.raw static -> inlined",
+    source: imp("sql`select * from person where ${sql.raw('age > 18')}`"),
+    output: { sql: "select * from person where age > 18" },
+  },
+  {
+    name: "sql.raw dynamic -> skip query",
+    source: imp("declare const cond: string; sql`select * from person where ${sql.raw(cond)}`"),
+    output: { sql: "select * from person where /* skipped */" },
+  },
+  {
+    name: "sql.join static array -> expanded params",
+    source: imp("sql`select * from person where id in (${sql.join([1, 2, 3])})`"),
+    output: { sql: "select * from person where id in ($N, $N, $N)" },
+  },
+  {
+    name: "sql.join with fragment separator",
+    source: imp("sql`select ${sql.join(['a', 'b'], sql` AND `)}`"),
+    output: { sql: "select $N AND $N" },
+  },
+  {
+    name: "nested sql fragment is spliced in",
+    source: imp("const cond = sql`age > ${18}`; sql`select * from person where ${cond}`"),
+    output: { sql: "select * from person where age > $N" },
+  },
+];
+
+describe("kysely plugin — onTarget", () => {
+  for (const c of targetCases) {
+    it(c.name, () => expect(driver.toSQL(c.source)).toEqual(c.output));
+  }
+});
+
+describe("kysely plugin — onExpression", () => {
+  for (const c of expressionCases) {
+    it(c.name, () => expect(driver.toSQL(c.source)).toEqual(c.output));
+  }
+});

--- a/packages/plugins/kysely/src/plugin.ts
+++ b/packages/plugins/kysely/src/plugin.ts
@@ -1,0 +1,845 @@
+import vm from "node:vm";
+import type { TSESTree } from "@typescript-eslint/utils";
+import {
+  CamelCasePlugin,
+  DummyDriver,
+  DeduplicateJoinsPlugin,
+  HandleEmptyInListsPlugin,
+  Kysely,
+  ParseJSONResultsPlugin,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  WithSchemaPlugin,
+  sql as kyselySql,
+} from "kysely";
+import {
+  ast,
+  type QuerySourceMapEntry,
+  type ResolveQueryContext,
+  definePlugin,
+  type TargetContext,
+  type TargetMatch,
+} from "@ts-safeql/plugin-utils";
+import ts from "typescript";
+import { migrate } from "./migrate";
+
+type KyselyPluginConfig = {
+  builder?: boolean;
+};
+
+const terminalBuilderMethods = new Set([
+  "execute",
+  "executeTakeFirst",
+  "executeTakeFirstOrThrow",
+  "compile",
+  "stream",
+]);
+
+const builderCompileTimeoutMs = 1000;
+
+const kyselyBuilderTypeNames = new Set([
+  "QueryCreator",
+  "Kysely",
+  "Transaction",
+  "ControlledTransaction",
+]);
+
+function isKyselyBuilderRoot(node: ts.Node, checker: ts.TypeChecker): boolean {
+  if (
+    !ts.isIdentifier(node) &&
+    !ts.isPropertyAccessExpression(node) &&
+    !ts.isElementAccessExpression(node) &&
+    node.kind !== ts.SyntaxKind.ThisKeyword
+  ) {
+    return false;
+  }
+
+  return typeDerivesFromKyselyBuilder(
+    checker.getApparentType(checker.getTypeAtLocation(node)),
+    checker,
+  );
+}
+
+// `checker.getBaseTypes` yields only direct bases, so recurse to reach QueryCreator from a
+// Transaction/ControlledTransaction or a user subclass of Kysely.
+function typeDerivesFromKyselyBuilder(type: ts.Type, checker: ts.TypeChecker): boolean {
+  const seen = new Set<ts.Type>();
+  const visit = (current: ts.Type): boolean => {
+    if (seen.has(current)) return false;
+    seen.add(current);
+
+    if (current.isUnionOrIntersection()) {
+      return current.types.some(visit);
+    }
+
+    if (symbolIsKyselyBuilder(current.getSymbol() ?? current.aliasSymbol, checker)) {
+      return true;
+    }
+
+    const bases = current.isClassOrInterface() ? checker.getBaseTypes(current) : [];
+    return bases.some(visit);
+  };
+
+  return visit(type);
+}
+
+function symbolIsKyselyBuilder(symbol: ts.Symbol | undefined, checker: ts.TypeChecker): boolean {
+  if (symbol === undefined || !kyselyBuilderTypeNames.has(symbol.getName())) {
+    return false;
+  }
+
+  return ast.isSymbolImportedFrom({ checker, symbol, moduleName: "kysely" });
+}
+
+const allowedBuilderPlugins = new Set([
+  "CamelCasePlugin",
+  "ParseJSONResultsPlugin",
+  "DeduplicateJoinsPlugin",
+  "WithSchemaPlugin",
+  "HandleEmptyInListsPlugin",
+]);
+
+// `(column, operator, value)` methods whose value slot is purely parameterized when the operator is scalar.
+const whereLikeMethods = new Set(["where", "having", "andWhere", "orWhere", "and", "or", "on"]);
+
+// Operators that compile a runtime value to a single bound param, so a free variable there is safe to stub.
+// Excludes operators whose value changes the SQL text (`in`, `is`, `any`/`all`/`some`).
+const safeValueOperators = new Set([
+  "=",
+  "==",
+  "!=",
+  "<>",
+  "<",
+  "<=",
+  ">",
+  ">=",
+  "like",
+  "not like",
+  "ilike",
+  "not ilike",
+  "~",
+  "~*",
+  "!~",
+  "!~*",
+  "@>",
+  "<@",
+]);
+
+// Property names that introduce SQL we cannot statically reconstruct.
+const blockedBuilderMemberNames = new Set(["with", "dynamic", "sql"]);
+
+// Stub for a free variable in a safe value position; its value is irrelevant (Kysely emits `$N`).
+const SAFE_VALUE_STUB = "1";
+
+export default definePlugin({
+  name: "kysely",
+  package: "@ts-safeql/plugin-kysely",
+  setup(config: KyselyPluginConfig = {}) {
+    const plugin = {
+      // No `targets`: `onTarget` is authoritative, validating only kysely `sql` tags.
+      onTarget,
+      onExpression,
+      migrate,
+    } as const;
+
+    if (config.builder === true) {
+      return {
+        ...plugin,
+        queryNodeKinds: [
+          { kind: "CallExpression", callee: { property: { nameIn: [...terminalBuilderMethods] } } },
+        ],
+        resolveQuery: (context) => resolveBuilderQuery(context),
+      };
+    }
+
+    return plugin;
+  },
+});
+
+function resolveBuilderQuery(
+  context: ResolveQueryContext,
+): { kind: "sql"; text: string; sourcemaps: QuerySourceMapEntry[] } | "skip" {
+  const tsNode = context.tsNode;
+  if (!ts.isCallExpression(tsNode) || !isTerminalBuilderCall(tsNode)) {
+    return "skip";
+  }
+
+  const sourceFile = tsNode.getSourceFile();
+  const chain = tsNode.expression;
+
+  const state: RenderState = { hasEmbeddedSql: false, fragments: [] };
+  const compileText = buildBuilderCompileText(chain, context.checker, sourceFile, state);
+  if (compileText === undefined) {
+    return skipBuilderQuery(
+      tsNode,
+      sourceFile,
+      "dynamic builder shape (a value drives the SQL text)",
+    );
+  }
+
+  // Builder mode only lints embedded raw `sql`; a pure builder is covered by Kysely's own types.
+  if (!state.hasEmbeddedSql) {
+    return skipBuilderQuery(tsNode, sourceFile, "no embedded raw sql to validate");
+  }
+
+  const resultSql = resolveBuilderQueryInSandbox(compileText);
+
+  if (!resultSql) {
+    return skipBuilderQuery(tsNode, sourceFile, "could not compile chain in sandbox");
+  }
+
+  builderStats.validated += 1;
+  logBuilderDebug(`validated (${builderStats.validated} total): ${truncate(resultSql)}`);
+
+  return {
+    kind: "sql",
+    text: resultSql,
+    sourcemaps: buildBuilderSourcemaps({ state, resultSql, tsNode, sourceFile }),
+  };
+}
+
+// Map compiled SQL back to the embedded fragment so DB errors squiggle source, not the generated
+// offset. One fragment → point at it; several (unattributable) → point at the whole chain.
+function buildBuilderSourcemaps(params: {
+  state: RenderState;
+  resultSql: string;
+  tsNode: ts.Node;
+  sourceFile: ts.SourceFile;
+}): QuerySourceMapEntry[] {
+  const { state, resultSql, tsNode, sourceFile } = params;
+  const nodeStart = tsNode.getStart(sourceFile);
+  const sourceText = sourceFile.text;
+
+  const target =
+    state.fragments.length === 1 ? state.fragments[0] : { start: nodeStart, end: tsNode.getEnd() };
+
+  const text = sourceText.slice(target.start, target.end);
+
+  return [
+    {
+      generated: { start: 0, end: resultSql.length, text: resultSql },
+      original: { start: target.start - nodeStart, end: target.end - nodeStart, text },
+      offset: 0,
+    },
+  ];
+}
+
+// Non-static queries are skipped silently (dynamic queries are idiomatic);
+// set `SAFEQL_DEBUG_KYSELY_BUILDER=1` to log validated/skipped counts and reasons.
+const builderStats = { validated: 0, skipped: 0 };
+
+function skipBuilderQuery(node: ts.Node, sourceFile: ts.SourceFile, reason: string): "skip" {
+  builderStats.skipped += 1;
+  logBuilderDebug(
+    `skipped (${builderStats.skipped} total): ${reason} — ${truncate(node.getText(sourceFile))}`,
+  );
+  return "skip";
+}
+
+function logBuilderDebug(message: string): void {
+  if (process.env.SAFEQL_DEBUG_KYSELY_BUILDER) {
+    // eslint-disable-next-line no-console
+    console.error(`[safeql:kysely:builder] ${message}`);
+  }
+}
+
+function truncate(text: string, max = 120): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+function onTarget({
+  node,
+  context,
+}: {
+  node: TSESTree.TaggedTemplateExpression;
+  context: TargetContext;
+}): TargetMatch | false | undefined {
+  const tsNode = context.parser.esTreeNodeToTSNodeMap.get(node);
+
+  if (!tsNode || !ts.isTaggedTemplateExpression(tsNode)) {
+    return undefined;
+  }
+
+  if (!isKyselyTag(tsNode.tag, context.checker)) {
+    return undefined;
+  }
+
+  // Fragments (nested templates, `.as()`, builder-method args) aren't standalone queries.
+  if (isFragmentUsage(tsNode)) {
+    return false;
+  }
+
+  return {};
+}
+
+function onExpression({
+  context,
+}: {
+  node: TSESTree.Expression;
+  context: { checker: ts.TypeChecker; precedingSQL: string; tsNode: ts.Node };
+}): string | false | undefined {
+  return buildExpressionSQL(context.tsNode, context.checker);
+}
+
+function isTerminalBuilderCall(node: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(node.expression)) {
+    return false;
+  }
+
+  return terminalBuilderMethods.has(node.expression.name.text);
+}
+
+function resolveBuilderQueryInSandbox(chain: string): string | undefined {
+  const database = buildBuilderDatabaseExpression();
+  const source = `
+    const __safeqlDb = ${database};
+    const __safeqlCompiled = ${chain};
+    if (!__safeqlCompiled || typeof __safeqlCompiled.sql !== "string") {
+      throw new Error("kysely-builder-not-a-compilation-result");
+    }
+    __safeqlResultSql = __safeqlCompiled.sql;
+  `;
+
+  const context = createBuilderContext();
+  try {
+    vm.createContext(context);
+    const script = new vm.Script(source, { filename: "safeql-kysely-builder.js" });
+    script.runInContext(context, { timeout: builderCompileTimeoutMs });
+  } catch {
+    return undefined;
+  }
+
+  const value = context.__safeqlResultSql;
+  return typeof value === "string" ? value : undefined;
+}
+
+// Scope-limiting globals (not a security boundary — `vm` can be escaped): only these Kysely
+// building blocks are in scope, so any other free reference throws (→ skip) rather than
+// silently corrupting the compiled SQL.
+function createBuilderContext(): Record<string, unknown> {
+  return {
+    CamelCasePlugin,
+    ParseJSONResultsPlugin,
+    DeduplicateJoinsPlugin,
+    WithSchemaPlugin,
+    HandleEmptyInListsPlugin,
+    Kysely,
+    DummyDriver,
+    PostgresAdapter,
+    PostgresIntrospector,
+    PostgresQueryCompiler,
+    sql: kyselySql,
+    __safeqlResultSql: undefined,
+  };
+}
+
+interface RenderState {
+  hasEmbeddedSql: boolean;
+  fragments: Array<{ start: number; end: number }>;
+}
+
+function buildBuilderCompileText(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  state: RenderState,
+): string | undefined {
+  if (!ts.isPropertyAccessExpression(expression)) {
+    return undefined;
+  }
+
+  const chainText = renderBuilderChain(expression.expression, checker, sourceFile, state);
+  if (chainText === undefined) {
+    return undefined;
+  }
+
+  return `${chainText}.compile()`;
+}
+
+function renderBuilderChain(
+  node: ts.Expression,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  state: RenderState,
+): string | undefined {
+  const unwrapped = ast.unwrap({ node: node });
+
+  // The CallExpression guard keeps `db.withSchema(...)` — also `Kysely<DB>`-typed — in the chain
+  // rather than treating it as the root.
+  if (!ts.isCallExpression(unwrapped) && isKyselyBuilderRoot(unwrapped, checker)) {
+    return "__safeqlDb";
+  }
+
+  // A statically-constructed Kysely plugin, e.g. `.withPlugin(new CamelCasePlugin())`.
+  if (ts.isNewExpression(unwrapped)) {
+    return renderPluginConstruction(unwrapped, checker, sourceFile);
+  }
+
+  if (ts.isPropertyAccessExpression(unwrapped)) {
+    if (blockedBuilderMemberNames.has(unwrapped.name.text)) {
+      return undefined;
+    }
+
+    const receiverText = renderBuilderChain(unwrapped.expression, checker, sourceFile, state);
+    if (receiverText === undefined) {
+      return undefined;
+    }
+
+    return `${receiverText}.${unwrapped.name.text}`;
+  }
+
+  if (ts.isCallExpression(unwrapped)) {
+    const calleeText = renderBuilderChain(unwrapped.expression, checker, sourceFile, state);
+    if (calleeText === undefined) {
+      return undefined;
+    }
+
+    const argsText = renderCallArguments(unwrapped, checker, sourceFile, state);
+    if (argsText === undefined) {
+      return undefined;
+    }
+
+    return `${calleeText}(${argsText})`;
+  }
+
+  // Anything else here is a free variable in a structural position → not reconstructible.
+  return undefined;
+}
+
+function renderPluginConstruction(
+  node: ts.NewExpression,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+): string | undefined {
+  if (!ts.isIdentifier(node.expression) || !allowedBuilderPlugins.has(node.expression.text)) {
+    return undefined;
+  }
+
+  const args = node.arguments ?? [];
+  const rendered: string[] = [];
+  for (const arg of args) {
+    const value = ast.getStaticValue({ node: arg, checker: checker });
+    if (value === ast.UNRESOLVED) {
+      return undefined;
+    }
+    rendered.push(staticValueToSource(value));
+  }
+
+  return `new ${node.expression.text}(${rendered.join(", ")})`;
+}
+
+// Only the value slot of a scalar where-like call may be a free variable (→ bound param); other args must be static.
+function renderCallArguments(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  state: RenderState,
+): string | undefined {
+  const methodName = ts.isPropertyAccessExpression(call.expression)
+    ? call.expression.name.text
+    : undefined;
+  const args = call.arguments;
+
+  if (
+    methodName !== undefined &&
+    whereLikeMethods.has(methodName) &&
+    args.length === 3 &&
+    !isKyselySqlExpression(args[0], checker)
+  ) {
+    const column = ast.getStaticValue({ node: args[0], checker: checker });
+    const operator = ast.getStaticValue({ node: args[1], checker: checker });
+    if (typeof column !== "string" || typeof operator !== "string") {
+      // Dynamic column/operator drives SQL structure → skip.
+      return undefined;
+    }
+
+    const value = ast.getStaticValue({ node: args[2], checker: checker });
+    let valueText: string;
+    if (value !== ast.UNRESOLVED) {
+      valueText = staticValueToSource(value);
+    } else if (safeValueOperators.has(operator)) {
+      valueText = SAFE_VALUE_STUB;
+    } else {
+      return undefined;
+    }
+
+    return [staticValueToSource(column), staticValueToSource(operator), valueText].join(", ");
+  }
+
+  const rendered: string[] = [];
+  for (const arg of args) {
+    const argText = renderArgumentValue(arg, checker, sourceFile, state);
+    if (argText === undefined) {
+      return undefined;
+    }
+    rendered.push(argText);
+  }
+
+  return rendered.join(", ");
+}
+
+/**
+ * Render a single argument value: a static literal, an array of them, an
+ * allowed plugin construction, or an embedded `sql` fragment (possibly with a
+ * `.as(...)`/method chain). Anything else (callbacks, free variables in a
+ * structural position) → `undefined` (skip).
+ */
+function renderArgumentValue(
+  arg: ts.Expression,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  state: RenderState,
+): string | undefined {
+  const unwrapped = ast.unwrap({ node: arg });
+
+  if (ts.isFunctionLike(unwrapped) || ts.isSpreadElement(unwrapped)) {
+    return undefined;
+  }
+
+  if (containsKyselySqlFragment(unwrapped, checker)) {
+    return renderSqlExpressionChain(unwrapped, checker, sourceFile, state);
+  }
+
+  if (ts.isArrayLiteralExpression(unwrapped)) {
+    const elements: string[] = [];
+    for (const element of unwrapped.elements) {
+      if (ts.isSpreadElement(element)) {
+        return undefined;
+      }
+      const rendered = renderArgumentValue(element, checker, sourceFile, state);
+      if (rendered === undefined) {
+        return undefined;
+      }
+      elements.push(rendered);
+    }
+    return `[${elements.join(", ")}]`;
+  }
+
+  if (ts.isNewExpression(unwrapped)) {
+    return renderPluginConstruction(unwrapped, checker, sourceFile);
+  }
+
+  const value = ast.getStaticValue({ node: unwrapped, checker: checker });
+  if (value === ast.UNRESOLVED) {
+    return undefined;
+  }
+
+  return staticValueToSource(value);
+}
+
+function isKyselySqlExpression(node: ts.Node, checker: ts.TypeChecker): boolean {
+  return containsKyselySqlFragment(ast.unwrap({ node: node }), checker);
+}
+
+function containsKyselySqlFragment(node: ts.Node, checker: ts.TypeChecker): boolean {
+  const u = ast.unwrap({ node: node });
+  if (isKyselySqlTaggedTemplate(u, checker)) return true;
+  if (ts.isCallExpression(u)) return containsKyselySqlFragment(u.expression, checker);
+  if (ts.isPropertyAccessExpression(u)) return containsKyselySqlFragment(u.expression, checker);
+  return false;
+}
+
+function isKyselySqlTaggedTemplate(
+  node: ts.Node,
+  checker: ts.TypeChecker,
+): node is ts.TaggedTemplateExpression {
+  return ts.isTaggedTemplateExpression(node) && isKyselyTag(node.tag, checker);
+}
+
+function renderSqlExpressionChain(
+  node: ts.Node,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  state: RenderState,
+): string | undefined {
+  const u = ast.unwrap({ node: node });
+
+  if (isKyselySqlTaggedTemplate(u, checker)) {
+    state.hasEmbeddedSql = true;
+    state.fragments.push({ start: u.getStart(sourceFile), end: u.getEnd() });
+    return renderEmbeddedSqlFragment(u.template, checker, sourceFile);
+  }
+
+  if (ts.isCallExpression(u)) {
+    const callee = renderSqlExpressionChain(u.expression, checker, sourceFile, state);
+    if (callee === undefined) return undefined;
+
+    const args: string[] = [];
+    for (const arg of u.arguments) {
+      const rendered = renderArgumentValue(arg, checker, sourceFile, state);
+      if (rendered === undefined) return undefined;
+      args.push(rendered);
+    }
+    return `${callee}(${args.join(", ")})`;
+  }
+
+  if (ts.isPropertyAccessExpression(u)) {
+    const receiver = renderSqlExpressionChain(u.expression, checker, sourceFile, state);
+    if (receiver === undefined) return undefined;
+    return `${receiver}.${u.name.text}`;
+  }
+
+  return undefined;
+}
+
+function renderEmbeddedSqlFragment(
+  template: ts.TemplateLiteral,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+): string {
+  if (ts.isNoSubstitutionTemplateLiteral(template)) {
+    return `sql\`${escapeTemplateText(template.text)}\``;
+  }
+
+  let out = `sql\`${escapeTemplateText(template.head.text)}`;
+  for (const span of template.templateSpans) {
+    out += `\${${renderInterpolation(span.expression, checker, sourceFile)}}`;
+    out += escapeTemplateText(span.literal.text);
+  }
+  return `${out}\``;
+}
+
+function renderInterpolation(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+): string {
+  const u = ast.unwrap({ node: expr });
+
+  // A kysely helper or nested `sql` fragment is evaluated as-is (dynamic arg throws → skip); anything else → value stub.
+  if (
+    isKyselySqlTaggedTemplate(u, checker) ||
+    (ts.isCallExpression(u) && isKyselyHelperCall(u, checker))
+  ) {
+    return u.getText(sourceFile);
+  }
+
+  return SAFE_VALUE_STUB;
+}
+
+function escapeTemplateText(text: string): string {
+  return text.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+}
+
+function staticValueToSource(value: ast.StaticValue): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(staticValueToSource).join(", ")}]`;
+  }
+  return String(value);
+}
+
+function buildBuilderDatabaseExpression(): string {
+  // No plugins on the base DB; identifier-rewriting plugins are applied inline via `.withPlugin(...)` in the chain.
+  return `new Kysely({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+    plugins: [],
+  })`;
+}
+
+function buildExpressionSQL(node: ts.Node, checker: ts.TypeChecker): string | false | undefined {
+  const expression = ast.unwrap({ node: node });
+
+  if (ts.isTaggedTemplateExpression(expression) && isKyselyTag(expression.tag, checker)) {
+    return buildTemplateSQL(expression.template, checker);
+  }
+
+  if (ts.isIdentifier(expression)) {
+    const initializer = ast.findInitializer({ identifier: expression, checker: checker });
+    return initializer ? buildExpressionSQL(initializer, checker) : undefined;
+  }
+
+  if (!ts.isCallExpression(expression) || !isKyselyHelperCall(expression, checker)) {
+    return undefined;
+  }
+
+  return buildHelperSQL(expression, checker);
+}
+
+function buildHelperSQL(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): string | false | undefined {
+  const method = getMethodName(call);
+  const args = call.arguments;
+
+  switch (method) {
+    case "val":
+    case "value":
+      // Bare placeholder (no cast); let Postgres infer the type.
+      return "$N";
+
+    case "ref":
+    case "table": {
+      const value = ast.getStaticValue({ node: args[0], checker: checker });
+      return typeof value === "string" ? quoteIdentifierPath(value) : false;
+    }
+
+    case "id": {
+      const parts: string[] = [];
+      for (const arg of args) {
+        const value = ast.getStaticValue({ node: arg, checker: checker });
+        if (typeof value !== "string") return false;
+        parts.push(value);
+      }
+      return parts.length > 0 ? parts.map(quoteIdentifier).join(".") : false;
+    }
+
+    case "lit":
+    case "literal": {
+      const value = ast.getStaticValue({ node: args[0], checker: checker });
+      return formatLiteral(value);
+    }
+
+    case "raw": {
+      const value = ast.getStaticValue({ node: args[0], checker: checker });
+      return typeof value === "string" ? value : false;
+    }
+
+    case "join":
+      return buildJoinSQL(call, checker);
+
+    default:
+      return undefined;
+  }
+}
+
+function buildJoinSQL(call: ts.CallExpression, checker: ts.TypeChecker): string | false {
+  const values = ast.getStaticValue({ node: call.arguments[0], checker: checker });
+  if (!Array.isArray(values)) return false;
+
+  const separator = getJoinSeparator(call.arguments[1], checker);
+  if (separator === false) return false;
+
+  return values.map(() => "$N").join(separator);
+}
+
+function getJoinSeparator(arg: ts.Expression | undefined, checker: ts.TypeChecker): string | false {
+  if (arg === undefined) return ", ";
+
+  // Only a literal `sql`...`` separator is resolved; a variable separator skips the query rather than guessing.
+  const expression = ast.unwrap({ node: arg });
+  if (ts.isTaggedTemplateExpression(expression) && isKyselyTag(expression.tag, checker)) {
+    const text = buildTemplateSQL(expression.template, checker);
+    return typeof text === "string" ? text : false;
+  }
+
+  return false;
+}
+
+function buildTemplateSQL(
+  template: ts.NoSubstitutionTemplateLiteral | ts.TemplateExpression,
+  checker: ts.TypeChecker,
+): string | false {
+  if (ts.isNoSubstitutionTemplateLiteral(template)) {
+    return template.text;
+  }
+
+  let sql = template.head.text;
+
+  for (const span of template.templateSpans) {
+    const resolved = buildExpressionSQL(span.expression, checker);
+    if (resolved === false) return false;
+    sql += typeof resolved === "string" ? resolved : "$N";
+    sql += span.literal.text;
+  }
+
+  return sql;
+}
+
+function isFragmentUsage(tsNode: ts.TaggedTemplateExpression): boolean {
+  if (tsNode.parent && ts.isTemplateSpan(tsNode.parent)) {
+    return true;
+  }
+
+  let current: ts.Node = tsNode;
+  let parent = current.parent;
+
+  while (parent) {
+    if (ts.isPropertyAccessExpression(parent) && parent.expression === current) {
+      // `.as(...)` marks a selection fragment, never a standalone query.
+      if (["as", "toOperationNode"].includes(parent.name.text)) return true;
+      current = parent;
+      parent = current.parent;
+      continue;
+    }
+
+    if (
+      (ts.isCallExpression(parent) ||
+        ts.isAwaitExpression(parent) ||
+        ts.isParenthesizedExpression(parent) ||
+        ts.isAsExpression(parent) ||
+        ts.isNonNullExpression(parent)) &&
+      getInnerExpression(parent) === current
+    ) {
+      current = parent;
+      parent = current.parent;
+      continue;
+    }
+
+    break;
+  }
+
+  // Passed as a call argument (e.g. `.where(sql`...`)`) → fragment.
+  return (
+    parent !== undefined &&
+    ts.isCallExpression(parent) &&
+    parent.arguments.some((arg) => arg === current)
+  );
+}
+
+function getInnerExpression(node: ts.Node): ts.Node | undefined {
+  if (ts.isCallExpression(node)) return node.expression;
+  if (
+    ts.isAwaitExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isNonNullExpression(node)
+  ) {
+    return node.expression;
+  }
+  return undefined;
+}
+
+function isKyselyTag(node: ts.Node, checker: ts.TypeChecker): boolean {
+  return ast.isImportedFrom({ node: node, checker: checker, moduleName: "kysely" });
+}
+
+function isKyselyHelperCall(call: ts.CallExpression, checker: ts.TypeChecker): boolean {
+  return ts.isPropertyAccessExpression(call.expression) && isKyselyTag(call.expression, checker);
+}
+
+function getMethodName(call: ts.CallExpression): string | undefined {
+  return ts.isPropertyAccessExpression(call.expression) ? call.expression.name.text : undefined;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function quoteIdentifierPath(value: string): string {
+  return value.split(".").map(quoteIdentifier).join(".");
+}
+
+function formatLiteral(value: ast.StaticValue | typeof ast.UNRESOLVED): string | false {
+  if (value === ast.UNRESOLVED) return false;
+  if (typeof value === "string") return `'${value.replace(/'/g, "''")}'`;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  if (value === null) return "null";
+  return false;
+}

--- a/packages/plugins/kysely/src/ts-fixture/file.ts
+++ b/packages/plugins/kysely/src/ts-fixture/file.ts
@@ -1,0 +1,1 @@
+// File needs to exist for @typescript-eslint/parser projectService

--- a/packages/plugins/kysely/src/ts-fixture/tsconfig.json
+++ b/packages/plugins/kysely/src/ts-fixture/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*"]
+}

--- a/packages/plugins/kysely/tsconfig.json
+++ b/packages/plugins/kysely/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/packages/plugins/kysely/vitest.config.ts
+++ b/packages/plugins/kysely/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import shared from "../../../vitest.shared";
+
+export default mergeConfig(
+  shared,
+  defineConfig({
+    test: {
+      pool: "forks",
+    },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,43 @@ importers:
         specifier: 'catalog:'
         version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
 
+  demos/plugin-kysely:
+    dependencies:
+      '@ts-safeql/eslint-plugin':
+        specifier: workspace:*
+        version: link:../../packages/eslint-plugin
+      '@ts-safeql/plugin-kysely':
+        specifier: workspace:*
+        version: link:../../packages/plugins/kysely
+    devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 10.0.1(eslint@10.0.3(jiti@2.4.2))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.11.11
+      eslint:
+        specifier: 'catalog:'
+        version: 10.0.3(jiti@2.4.2)
+      kysely:
+        specifier: ^0.28.2
+        version: 0.28.17
+      pg:
+        specifier: ^8.13.1
+        version: 8.20.0
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
+
   demos/plugin-slonik:
     dependencies:
       '@ts-safeql/eslint-plugin':
@@ -874,6 +911,54 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.2
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.5.0(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(vite@6.2.3(@types/node@24.12.0)(jiti@2.4.2)(tsx@4.19.3))
+
+  packages/plugins/kysely:
+    devDependencies:
+      '@ts-safeql/eslint-plugin':
+        specifier: workspace:*
+        version: link:../../eslint-plugin
+      '@ts-safeql/plugin-utils':
+        specifier: workspace:*
+        version: link:../../plugin-utils
+      '@ts-safeql/test-utils':
+        specifier: workspace:*
+        version: link:../../test-utils
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.11.11
+      '@typescript-eslint/parser':
+        specifier: 'catalog:'
+        version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/rule-tester':
+        specifier: 'catalog:'
+        version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils':
+        specifier: 'catalog:'
+        version: 8.57.1(eslint@10.0.3(jiti@2.4.2))(typescript@5.8.2)
+      kysely:
+        specifier: ^0.28.2
+        version: 0.28.17
+      pg:
+        specifier: ^8.13.1
+        version: 8.20.0
+      postgres:
+        specifier: 'catalog:'
+        version: 3.4.7
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -3398,6 +3483,10 @@ packages:
   knitwork@1.2.0:
     resolution: {integrity: sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==}
 
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
+    engines: {node: '>=20.0.0'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -3698,10 +3787,6 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
-
-  pg-types@4.0.2:
-    resolution: {integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==}
-    engines: {node: '>=10'}
 
   pg-types@4.1.0:
     resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
@@ -6275,14 +6360,14 @@ snapshots:
   '@types/pg@8.11.11':
     dependencies:
       '@types/node': 24.12.0
-      pg-protocol: 1.8.0
-      pg-types: 4.0.2
+      pg-protocol: 1.13.0
+      pg-types: 4.1.0
 
   '@types/pg@8.11.6':
     dependencies:
       '@types/node': 24.12.0
-      pg-protocol: 1.8.0
-      pg-types: 4.0.2
+      pg-protocol: 1.13.0
+      pg-types: 4.1.0
 
   '@types/resolve@1.20.2': {}
 
@@ -7304,6 +7389,8 @@ snapshots:
 
   knitwork@1.2.0: {}
 
+  kysely@0.28.17: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -7584,16 +7671,6 @@ snapshots:
       postgres-bytea: 1.0.0
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
-
-  pg-types@4.0.2:
-    dependencies:
-      pg-int8: 1.0.1
-      pg-numeric: 1.0.2
-      postgres-array: 3.0.4
-      postgres-bytea: 3.0.0
-      postgres-date: 2.1.0
-      postgres-interval: 3.0.0
-      postgres-range: 1.1.4
 
   pg-types@4.1.0:
     dependencies:


### PR DESCRIPTION
Stacked on #490.

Adds the Kysely plugin (`@ts-safeql/plugin-kysely`):
- Validates standalone raw `sql` queries and, with `builder: true`, the raw-`sql` fragments embedded inside Kysely query-builder chains.
- Builds the shadow database from Kysely TypeScript migrations via the `migrate` hook.

Pure builder queries (no raw `sql`) stay covered by Kysely's own types. Includes a demo app and compatibility docs. Lockfile regenerated for the new `kysely`/`pg` deps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kysely support with validation for SQL template queries.
  * Query builder mode validates embedded SQL in Kysely chains.
  * Migrations automatically build shadow databases for schema validation.
  * Added CamelCase field mapping support.
  * Added comprehensive Kysely documentation and demo examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->