### PR TITLE
ci: raise Node heap to avoid V8 OOM on cold runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      # Cold runs build/lint/test every package fresh; the default V8 heap is too small for the
+      # largest TypeScript programs and aborts with `v8::ToLocalChecked Empty MaybeLocal`.
+      NODE_OPTIONS: "--max-old-space-size=4096"
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v6


### PR DESCRIPTION
Cold CI runs (when a PR changes the lockfile and the Turbo remote cache is rate-limited) build/lint/test every package fresh and in parallel. The largest TypeScript programs exceed the default V8 heap and the process aborts with `FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal` (exit 134) — surfacing in whichever task is running (recently `demos/config-file-flat-config` lint).

Raise the heap via `NODE_OPTIONS=--max-old-space-size=4096` so cold runs don't OOM. Not specific to any package; it's a CI fragility that any lockfile-changing PR can trip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow performance for build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->