### PR TITLE
ci: cap lint/test concurrency to avoid libpg-query crash on cold runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
           PGDATABASE: postgres
       - run: pnpm build
       - run: pnpm typecheck
-      - run: pnpm lint
+      # `lint` and `test` parse SQL via libpg-query in synckit workers; spawning many in parallel
+      # on a cold run exhausts native resources and aborts (`v8::ToLocalChecked Empty MaybeLocal`).
+      # Call turbo directly so `--concurrency` is turbo's flag, not forwarded to eslint/vitest.
+      - run: pnpm exec turbo run lint --concurrency=1
       - run: pnpm format
-      - run: pnpm test
+      - run: pnpm exec turbo run test --concurrency=2


### PR DESCRIPTION
Cold runs spawn many libpg-query/synckit workers in parallel and abort with `v8::ToLocalChecked Empty MaybeLocal` (exit 134) during `lint` (seen in config-file-flat-config, then playground — whichever runs when resources are exhausted). Raising the heap (already merged) didn't help, so it's native-worker contention, not V8 heap. Run `lint` serially and `test` at concurrency 2 to bound concurrent native workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow to run linting and tests via the build orchestrator with controlled parallelism, improving stability on cold runs and reducing the risk of resource-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->