### PR TITLE
ci: revert ineffective heap/concurrency tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      # Cold runs build/lint/test every package fresh; the default V8 heap is too small for the
-      # largest TypeScript programs and aborts with `v8::ToLocalChecked Empty MaybeLocal`.
-      NODE_OPTIONS: "--max-old-space-size=4096"
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v6
@@ -53,9 +50,6 @@ jobs:
           PGDATABASE: postgres
       - run: pnpm build
       - run: pnpm typecheck
-      # `lint` and `test` parse SQL via libpg-query in synckit workers; spawning many in parallel
-      # on a cold run exhausts native resources and aborts (`v8::ToLocalChecked Empty MaybeLocal`).
-      # Call turbo directly so `--concurrency` is turbo's flag, not forwarded to eslint/vitest.
-      - run: pnpm exec turbo run lint --concurrency=1
+      - run: pnpm lint
       - run: pnpm format
-      - run: pnpm exec turbo run test --concurrency=2
+      - run: pnpm test


### PR DESCRIPTION
Reverts #493 (NODE_OPTIONS heap bump) and #494 (lint/test concurrency caps). Neither fixed the cold-run `v8::ToLocalChecked` crash — they were band-aids. Restoring ci.yml to its pristine state while the real cause is pinned down (a faithful x64-Linux repro is in progress).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to streamline build execution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->