### PR TITLE
fix(generate): improve nullability inference for booleans, CTEs, and subselects

### DIFF
--- a/.agents/docs/coding-guidelines.md
+++ b/.agents/docs/coding-guidelines.md
@@ -4,6 +4,8 @@ No headline comments. Don't use comments as section dividers (e.g., `// ---- Hel
 
 No comments that explain what code does. If a comment restates the code below it, the code isn't clear enough. Rename, extract, or restructure instead. A comment like `// Check if the user is valid` above `if (isValidUser(u))` is noise. Comments should explain why, not what.
 
+Comments must be timeless. Write for a reader seeing the code fresh, not for a reviewer of the current diff. Don't justify the code relative to a change or its previous state — phrases like "now rule-agnostic", "intentionally X (both A and B share…)", "simplified to…", "no longer needs…", "moved from…". Once committed, that context is gone and the comment only confuses. If the rationale still matters independent of the change, state it as a standing fact; otherwise delete it.
+
 Exception: `// ARRANGE`, `// ACT`, `// ASSERT` comments in tests are allowed.
 
 Avoid using `any`, `as unknown as`, or any unsafe casts. Use type inference and type guards instead.

--- a/.changeset/fix-nullability-inference.md
+++ b/.changeset/fix-nullability-inference.md
@@ -1,0 +1,8 @@
+---
+"@ts-safeql/generate": patch
+"@ts-safeql/eslint-plugin": patch
+---
+
+Fix SQL type inference for nullable booleans, CTEs, and subselects.
+
+Nullable boolean expressions (for example `CASE WHEN … THEN col = 1 ELSE NULL END`) now infer `boolean | null` instead of being dropped. Columns selected through CTEs or subselects keep the nullability from their defining query, including after `LEFT JOIN`. Column references inside those scopes also resolve against the selected output name, not only an explicit alias.

--- a/demos/big-project/src/test.ts
+++ b/demos/big-project/src/test.ts
@@ -5,7 +5,7 @@ import path from "path";
 const __dirname = new URL(".", import.meta.url).pathname;
 
 const FAKE_SRC_PATH = path.join(__dirname, "..", "_fake_src");
-const MAX_TIME = /* 90 seconds */ 90 * 1000;
+const MAX_TIME = /* 120 seconds */ 120 * 1000;
 const TOTAL_FILES = 3000;
 
 async function before() {

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -459,7 +459,7 @@ function getDescribedAExpr({
           name,
           type: resolveType({
             context,
-            nullable: true,
+            nullable: !context.nonNullableColumns.has(name),
             type: context.toTypeScriptType({ name: "bool" }),
           }),
         },
@@ -1270,15 +1270,8 @@ function resTargetMatchesColumn(
 }
 
 function getAliasOrColumnRefName(target: LibPgQueryAST.ResTarget): string | undefined {
-  if (target.name !== undefined) {
-    return target.name;
-  }
-
-  if (target.val?.ColumnRef === undefined) {
-    return undefined;
-  }
-
-  return target.val.ColumnRef.fields?.at(-1)?.String?.sval;
+  const name = getOutputColumnKey(target.name, target.val);
+  return name === "?column?" ? undefined : name;
 }
 
 function getContextForColumnRef(

--- a/packages/generate/src/ast-describe.ts
+++ b/packages/generate/src/ast-describe.ts
@@ -47,6 +47,24 @@ type ASTDescriptionContext = ASTDescriptionOptions & {
 
 export type ASTDescribedColumn = { name: string; type: ASTDescribedColumnType };
 
+const booleanAExprOperators = new Set([
+  "=",
+  "<>",
+  "!=",
+  "<",
+  ">",
+  "<=",
+  ">=",
+  "~~",
+  "!~~",
+  "~~*",
+  "!~~*",
+  "~",
+  "!~",
+  "~*",
+  "!~*",
+]);
+
 export type ASTDescribedColumnType =
   | { kind: "union"; value: ASTDescribedColumnType[] }
   | { kind: "array"; value: ASTDescribedColumnType }
@@ -435,6 +453,19 @@ function getDescribedAExpr({
   const operator = concatStringNodes(node.name);
 
   if (lnode === null || rnode === null) {
+    if (isBooleanAExprOperator(operator)) {
+      return [
+        {
+          name,
+          type: resolveType({
+            context,
+            nullable: true,
+            type: context.toTypeScriptType({ name: "bool" }),
+          }),
+        },
+      ];
+    }
+
     return [];
   }
 
@@ -1209,19 +1240,45 @@ function getColumnRefOrigins({
       // lookup in cte
       context.select.withClause?.ctes
         .find((cte) => cte.CommonTableExpr?.ctename === source)
-        ?.CommonTableExpr?.ctequery?.SelectStmt?.targetList?.find(
-          (x) => x.ResTarget?.name === column,
+        ?.CommonTableExpr?.ctequery?.SelectStmt?.targetList?.find((x) =>
+          resTargetMatchesColumn(x.ResTarget, column),
         ) ??
       // lookup in subselect
       findRangeSubselectByAlias({
         fromClause: context.select.fromClause,
         alias: source,
-      })?.subquery?.SelectStmt?.targetList?.find((x) => x.ResTarget?.name === column);
+      })?.subquery?.SelectStmt?.targetList?.find((x) =>
+        resTargetMatchesColumn(x.ResTarget, column),
+      );
 
     if (!origin) return undefined;
 
     return [origin];
   }
+}
+
+function resTargetMatchesColumn(
+  target: LibPgQueryAST.ResTarget | undefined,
+  column: string,
+): boolean {
+  if (target === undefined) {
+    return false;
+  }
+
+  const outputName = getAliasOrColumnRefName(target);
+  return outputName !== undefined && outputName === column;
+}
+
+function getAliasOrColumnRefName(target: LibPgQueryAST.ResTarget): string | undefined {
+  if (target.name !== undefined) {
+    return target.name;
+  }
+
+  if (target.val?.ColumnRef === undefined) {
+    return undefined;
+  }
+
+  return target.val.ColumnRef.fields?.at(-1)?.String?.sval;
 }
 
 function getContextForColumnRef(
@@ -1569,6 +1626,10 @@ function concatStringNodes(nodes: LibPgQueryAST.Node[] | undefined): string {
       .filter(Boolean)
       .join(".") ?? ""
   );
+}
+
+function isBooleanAExprOperator(operator: string): boolean {
+  return booleanAExprOperators.has(operator);
 }
 
 function hasColumnReference(node: LibPgQueryAST.Node | undefined): boolean {

--- a/packages/generate/src/ast-get-sources.ts
+++ b/packages/generate/src/ast-get-sources.ts
@@ -84,6 +84,18 @@ export function getSources({
     }
   }
 
+  function getSelectAnalysis(select: LibPgQueryAST.SelectStmt) {
+    const parsed: LibPgQueryAST.ParseResult = {
+      version: 0,
+      stmts: [{ stmt: { SelectStmt: select }, stmtLocation: 0, stmtLen: 0 }],
+    };
+
+    return {
+      relations: flattenRelationsWithJoinsMap(getRelationsWithJoins(parsed)),
+      nonNullableColumns: getNonNullableColumns(parsed, { aggregateNames: pgAggregateNames }),
+    };
+  }
+
   function getColumnCTEs(ctes: LibPgQueryAST.Node[]): Map<string, SourcesResolver> {
     const map = new Map<string, SourcesResolver>();
 
@@ -91,15 +103,17 @@ export function getSources({
       if (cte.CommonTableExpr?.ctequery?.SelectStmt === undefined) continue;
       if (cte.CommonTableExpr?.ctename === undefined) continue;
 
+      const cteSelect = cte.CommonTableExpr.ctequery.SelectStmt;
+      const analysis = getSelectAnalysis(cteSelect);
       const resolver = getSources({
         pgColsBySchemaAndTableName,
         pgViewsBySchemaAndName,
         pgAggregateNames,
         prevSources,
-        nonNullableColumns,
-        relations,
+        nonNullableColumns: analysis.nonNullableColumns,
+        relations: analysis.relations,
         visitedViews,
-        select: cte.CommonTableExpr.ctequery.SelectStmt,
+        select: cteSelect,
       });
 
       map.set(cte.CommonTableExpr.ctename, resolver);
@@ -183,6 +197,8 @@ export function getSources({
     }
 
     if (node.RangeSubselect?.subquery?.SelectStmt !== undefined) {
+      const subselect = node.RangeSubselect.subquery.SelectStmt;
+      const analysis = getSelectAnalysis(subselect);
       const combinedPrevSources = new Map([
         ...(prevSources?.entries() ?? []),
         ...sourcesArr.map((x) => [x.name, x] as const),
@@ -192,14 +208,14 @@ export function getSources({
         kind: "subselect",
         name: node.RangeSubselect.alias?.aliasname ?? "subselect",
         sources: getSources({
-          nonNullableColumns,
           pgColsBySchemaAndTableName,
           pgViewsBySchemaAndName,
           pgAggregateNames,
-          relations,
+          relations: analysis.relations,
           visitedViews,
           prevSources: combinedPrevSources,
-          select: node.RangeSubselect.subquery.SelectStmt,
+          nonNullableColumns: analysis.nonNullableColumns,
+          select: subselect,
         }),
       });
     }

--- a/packages/generate/src/generate/generate.case-when.test.ts
+++ b/packages/generate/src/generate/generate.case-when.test.ts
@@ -127,6 +127,32 @@ test("select case when expr is not null else is not null", async () => {
   });
 });
 
+test("select nullable boolean case expression", async () => {
+  await testQuery({
+    query: `
+      SELECT
+        CASE
+          WHEN TRUE THEN records.value = 1
+          ELSE NULL
+        END AS result
+      FROM
+        (VALUES (1)) AS records (value)
+    `,
+    expected: [
+      [
+        "result",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "boolean", type: "bool" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
 test("select count(1) + count(1)", async () => {
   await testQuery({
     query: `SELECT count(1) + count(1)`,

--- a/packages/generate/src/generate/generate.operators.test.ts
+++ b/packages/generate/src/generate/generate.operators.test.ts
@@ -108,6 +108,16 @@ test("'foo' LIKE 'f%' => boolean", async () => {
   });
 });
 
+test("like on unresolved operand honors nonNullableColumns", async () => {
+  await testQuery({
+    query: `
+      SELECT records.value LIKE '1' AS result
+      FROM (VALUES ('1')) AS records (value)
+    `,
+    expected: [["result", { kind: "type", value: "boolean", type: "bool" }]],
+  });
+});
+
 test("'foo' NOT LIKE 'f%' => boolean", async () => {
   await testQuery({
     query: `SELECT 'foo' NOT LIKE 'f%'`,

--- a/packages/generate/src/generate/generate.subselects.test.ts
+++ b/packages/generate/src/generate/generate.subselects.test.ts
@@ -92,6 +92,37 @@ test("select from cte with coalesce", async () => {
   });
 });
 
+test("left join nullable column stays nullable through cte", async () => {
+  await testQuery({
+    query: `
+      WITH
+        selected_records AS (
+          SELECT
+            pg_description.description
+          FROM
+            pg_class
+            LEFT JOIN pg_description ON FALSE
+        )
+      SELECT
+        selected_records.description
+      FROM
+        selected_records
+    `,
+    expected: [
+      [
+        "description",
+        {
+          kind: "union",
+          value: [
+            { kind: "type", value: "string", type: "text" },
+            { kind: "type", value: "null", type: "null" },
+          ],
+        },
+      ],
+    ],
+  });
+});
+
 test("multiple with statements that depend on each other", async () => {
   await testQuery({
     query: `

--- a/packages/generate/src/generate/generate.subselects.test.ts
+++ b/packages/generate/src/generate/generate.subselects.test.ts
@@ -92,6 +92,20 @@ test("select from cte with coalesce", async () => {
   });
 });
 
+test("select unaliased coalesce expression through cte", async () => {
+  await testQuery({
+    query: `
+      WITH t AS (
+        SELECT coalesce(first_name, 'unknown')
+        FROM member
+      )
+      SELECT t.coalesce
+      FROM t
+    `,
+    expected: [["coalesce", { kind: "type", type: "text", value: "string" }]],
+  });
+});
+
 test("left join nullable column stays nullable through cte", async () => {
   await testQuery({
     query: `


### PR DESCRIPTION
fixes https://github.com/ts-safeql/safeql/issues/498 https://github.com/ts-safeql/safeql/issues/499

Fixes three gaps in SQL type inference where SafeQL could drop a column type or mark a nullable column as non-null. Nullable boolean expressions, columns flowing through CTEs/subselects, and unaliased column references in nested scopes now infer types more accurately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved nullability for nullable boolean expressions, now inferring `boolean | null` instead of dropping `null`.
  * Improved nullability propagation across CTEs and nested subqueries, including `LEFT JOIN` scenarios.
  * Enhanced column resolution within nested query scopes for more accurate type inference.
* **Tests**
  * Added coverage for nullable boolean `CASE/ELSE`, `LIKE` with non-nullable operands, and nullability through CTEs/subselects (including `LEFT JOIN`).
* **Documentation**
  * Updated coding guidelines to require “timeless” comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->