### PR TITLE
ci(perf): add generate() benchmark and same-runner regression gate

### DIFF
--- a/.changeset/faster-query-generation.md
+++ b/.changeset/faster-query-generation.md
@@ -1,0 +1,5 @@
+---
+"@ts-safeql/generate": patch
+---
+
+Speed up query type generation. Queries that are linted repeatedly (watch mode, CI runs, or the same query reused across files) are now much faster, and per-query cost no longer grows with the size of your database schema.

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,110 @@
+name: Performance
+
+# Benchmarks generate() and the lint rule on the PR and base branches on the same
+# runner, then compares. Timings vary ~3x across runners, so only the delta counts.
+
+on:
+  pull_request:
+    paths:
+      - "packages/generate/**"
+      - "packages/eslint-plugin/**"
+      - ".github/workflows/perf.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: perf-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.17.0
+          cache: "pnpm"
+
+      - name: Benchmark PR
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build --filter='./packages/**'
+          pnpm --filter @ts-safeql/generate bench "$GITHUB_WORKSPACE/pr-generate.json"
+          pnpm --filter @ts-safeql/eslint-plugin bench "$GITHUB_WORKSPACE/pr-eslint.json"
+
+      # No base ref on manual runs, so the comparison is PR-only.
+      - name: Checkout base
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Benchmark base (PR harness, base library code)
+        if: github.event_name == 'pull_request'
+        run: |
+          # PR's harness against base's source, so the delta is the library change.
+          for pkg in generate eslint-plugin; do
+            rm -rf "base/packages/$pkg/bench"
+            cp -r "packages/$pkg/bench" "base/packages/$pkg/bench"
+            node -e "const f='base/packages/$pkg/package.json'; const p=require('./'+f); p.scripts.bench=p.scripts.bench||'tsx bench/bench.mts'; require('fs').writeFileSync(f, JSON.stringify(p,null,2))"
+          done
+          cd base
+          pnpm install --frozen-lockfile
+          pnpm build --filter='./packages/**'
+          pnpm --filter @ts-safeql/generate bench "$GITHUB_WORKSPACE/base-generate.json"
+          pnpm --filter @ts-safeql/eslint-plugin bench "$GITHUB_WORKSPACE/base-eslint.json"
+
+      - name: Compare
+        id: compare
+        if: github.event_name == 'pull_request'
+        run: |
+          rc=0
+          node packages/generate/bench/compare.mjs base-generate.json pr-generate.json msPerQueryDistinct 25 "generate() performance" >> perf-summary.md || rc=1
+          printf '\n' >> perf-summary.md
+          node packages/generate/bench/compare.mjs base-eslint.json pr-eslint.json msRuleOverhead 40 "check-sql lint-rule overhead" >> perf-summary.md || rc=1
+          cat perf-summary.md
+          exit $rc
+
+      - name: Comment on PR
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('perf-summary.md')) return;
+            const body = fs.readFileSync('perf-summary.md', 'utf8');
+            const marker = '<!-- safeql-perf -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            // only our own comment, not another bot's that quotes the marker
+            const existing = comments.find(
+              (c) => c.user?.login === "github-actions[bot]" && c.body?.includes(marker),
+            );
+            const fullBody = `${marker}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: fullBody });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: fullBody });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ generated
 .env
 .env.local
 .DS_Store
+packages/*/bench/.fixture/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/eslint-plugin/bench/bench.mts
+++ b/packages/eslint-plugin/bench/bench.mts
@@ -1,0 +1,157 @@
+// Benchmarks the check-sql rule end to end via the ESLint API, base vs PR on the
+// same runner. msRuleOverhead is the lint pass with the rule on minus off.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import postgres from "postgres";
+import rules from "../src/rules";
+import {
+  CHECK_SQL_POSTGRES_URL,
+  runCheckSqlMigrations,
+} from "../src/rules/check-sql/check-sql.migrations";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, ".fixture");
+const DB_NAME = "safeql_eslint_bench";
+const DB_URL = `postgres://postgres:postgres@localhost:5432/${DB_NAME}`;
+
+const FILES = 50;
+const QUERIES_PER_FILE = 15;
+const ROUNDS = 6;
+const EXTRA_TABLES = 150;
+
+const TEMPLATES = [
+  (n: number) =>
+    `sql<{ id: number; first_name: string }[]>\`SELECT id, first_name FROM member WHERE id = ${n}\``,
+  (n: number) =>
+    `sql<{ id: number; role: string }[]>\`SELECT id, role FROM member WHERE id > ${n}\``,
+  (n: number) => `sql<{ name: string }[]>\`SELECT name FROM team WHERE id = ${n}\``,
+  (n: number) =>
+    `sql<{ c: number }[]>\`SELECT count(*) AS c FROM member_team WHERE member_id <> ${n}\``,
+  (n: number) =>
+    `sql<{ id: number; name: string }[]>\`SELECT m.id, t.name FROM member m JOIN member_team mt ON mt.member_id = m.id JOIN team t ON t.id = mt.team_id WHERE m.id > ${n}\``,
+];
+
+function median(xs: number[]): number {
+  const sorted = xs.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+async function setupDb() {
+  const admin = postgres(CHECK_SQL_POSTGRES_URL, { onnotice: () => {} });
+  await admin.unsafe(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`);
+  await admin.unsafe(`CREATE DATABASE ${DB_NAME}`);
+  await admin.end();
+  const sql = postgres(DB_URL);
+  await runCheckSqlMigrations(sql);
+  let ddl = "";
+  for (let i = 0; i < EXTRA_TABLES; i++) {
+    ddl += `CREATE TABLE bulk_${i} (id int primary key, a text not null, b int);\n`;
+  }
+  await sql.unsafe(ddl);
+  await sql.end();
+}
+
+function writeFixture() {
+  fs.rmSync(FIXTURE, { recursive: true, force: true });
+  fs.mkdirSync(FIXTURE, { recursive: true });
+  fs.writeFileSync(
+    path.join(FIXTURE, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          skipLibCheck: true,
+          module: "esnext",
+          moduleResolution: "bundler",
+          noEmit: true,
+        },
+        include: ["**/*.ts"],
+      },
+      null,
+      2,
+    ),
+  );
+  const files: string[] = [];
+  for (let f = 0; f < FILES; f++) {
+    const body = Array.from({ length: QUERIES_PER_FILE }, (_, q) => {
+      const n = f * 1000 + q + 1;
+      return "  " + TEMPLATES[(f + q) % TEMPLATES.length](n) + ";";
+    }).join("\n");
+    const file = path.join(FIXTURE, `temp-${f}.ts`);
+    fs.writeFileSync(
+      file,
+      `import postgres from "postgres";\nexport function check${f}() {\n  const sql = postgres();\n${body}\n}\n`,
+    );
+    files.push(file);
+  }
+  return files;
+}
+
+function makeEslint(ruleOn: boolean) {
+  const connection = { databaseUrl: DB_URL, targets: [{ tag: "sql" }], keepAlive: true };
+  return new ESLint({
+    cwd: FIXTURE,
+    overrideConfigFile: true,
+    overrideConfig: [
+      {
+        files: ["**/*.ts"],
+        languageOptions: {
+          parser: tsParser,
+          parserOptions: { projectService: true, tsconfigRootDir: FIXTURE },
+        },
+        plugins: { "@ts-safeql": { rules: { "check-sql": rules["check-sql"] } } },
+        rules: { "@ts-safeql/check-sql": ruleOn ? ["error", { connections: connection }] : "off" },
+      },
+    ],
+  });
+}
+
+async function lint(ruleOn: boolean, files: string[]): Promise<number> {
+  const eslint = makeEslint(ruleOn);
+  const s = performance.now();
+  await eslint.lintFiles(files);
+  return performance.now() - s;
+}
+
+async function main() {
+  await setupDb();
+  const files = writeFixture();
+
+  await lint(true, files); // warm-up
+
+  // interleaved on/off so the delta cancels system noise
+  const onTimes: number[] = [];
+  const overheads: number[] = [];
+  for (let r = 0; r < ROUNDS; r++) {
+    const on = await lint(true, files);
+    const off = await lint(false, files);
+    onTimes.push(on);
+    overheads.push(Math.max(0, on - off));
+  }
+  fs.rmSync(FIXTURE, { recursive: true, force: true });
+
+  const msTotal = median(onTimes);
+  const msRuleOverhead = median(overheads);
+  const metrics = {
+    files: FILES,
+    queriesPerFile: QUERIES_PER_FILE,
+    rounds: ROUNDS,
+    msTotal: Number(msTotal.toFixed(0)),
+    msRuleOverhead: Number(msRuleOverhead.toFixed(0)),
+    nodeVersion: process.version,
+  };
+
+  const out = JSON.stringify(metrics, null, 2);
+  const dest = process.argv[2];
+  if (dest) fs.writeFileSync(dest, out);
+  console.log(out);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -47,6 +47,7 @@
     "build": "unbuild",
     "dev": "unbuild --stub",
     "test": "vitest",
+    "bench": "tsx bench/bench.mts",
     "lint": "eslint src",
     "lint!": "eslint src --fix",
     "publint": "publint",

--- a/packages/generate/bench/bench.mts
+++ b/packages/generate/bench/bench.mts
@@ -1,0 +1,104 @@
+// Benchmarks warm generate() ms/query, base vs PR on the same runner. distinct =
+// uncached path (the gate); repeated = result-cache path.
+import fs from "node:fs";
+import postgres from "postgres";
+import { createGenerator } from "../src/generate";
+import { runMigrations } from "../src/generate/generate.migrations";
+
+const ADMIN = "postgres://postgres:postgres@localhost:5432/postgres";
+const DB_NAME = "safeql_bench";
+const DB_URL = `postgres://postgres:postgres@localhost:5432/${DB_NAME}`;
+
+// pad to a realistic table count (the test migrations alone are too few)
+const EXTRA_TABLES = 200;
+
+const TEMPLATES: string[] = [
+  `SELECT id, first_name, last_name FROM member WHERE id = {N}`,
+  `SELECT * FROM all_types WHERE int_column = {N}`,
+  `SELECT m.id, m.first_name, t.name FROM member m JOIN member_team mt ON mt.member_id = m.id JOIN team t ON t.id = mt.team_id WHERE m.id > {N}`,
+  `SELECT m.id, ma.role FROM member m LEFT JOIN member_assignment ma ON ma.member_id = m.id WHERE m.id < {N}`,
+  `SELECT count(*) AS c, max(id) AS m FROM member WHERE id <> {N}`,
+  `WITH t AS (SELECT id, first_name FROM member WHERE id > {N}) SELECT t.id, t.first_name FROM t`,
+  `SELECT id, first_name FROM (SELECT id, first_name FROM member WHERE id >= {N}) sub WHERE sub.id < {N}0`,
+  `SELECT id, CASE WHEN id > {N} THEN 'big' ELSE 'small' END AS sz FROM member`,
+  `SELECT jsonb_build_object('id', id, 'name', first_name) AS obj FROM member WHERE id = {N}`,
+  `SELECT m.id, COALESCE(ma.role, 'guest') AS role FROM member m LEFT JOIN member_assignment ma ON ma.member_id = m.id WHERE m.id = {N}`,
+];
+
+const QUERIES = 2000;
+const ROUNDS = 8;
+
+function median(xs: number[]): number {
+  const sorted = xs.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+async function setupDb() {
+  const admin = postgres(ADMIN, { onnotice: () => {} });
+  await admin.unsafe(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`);
+  await admin.unsafe(`CREATE DATABASE ${DB_NAME}`);
+  await admin.end();
+  const sql = postgres(DB_URL);
+  await runMigrations(sql);
+  let ddl = "";
+  for (let i = 0; i < EXTRA_TABLES; i++) {
+    ddl += `CREATE TABLE bulk_${i} (id int primary key, a text not null, b int, c timestamptz, d jsonb);\n`;
+  }
+  await sql.unsafe(ddl);
+  await sql.end();
+}
+
+type Decorate = (text: string, round: number, index: number) => string;
+
+async function measure(decorate: Decorate) {
+  const sql = postgres(DB_URL);
+  const generator = createGenerator();
+  const base = Array.from({ length: QUERIES }, (_, i) =>
+    TEMPLATES[i % TEMPLATES.length].replace(/\{N\}/g, String(i + 1)),
+  );
+  const gen = (text: string) =>
+    generator.generate({
+      sql,
+      query: { text, sourcemaps: [] },
+      cacheKey: DB_URL,
+      fieldTransform: undefined,
+    });
+
+  for (let i = 0; i < 300; i++) await gen(decorate(base[i % base.length], -1, i));
+
+  const perRound: number[] = [];
+  for (let r = 0; r < ROUNDS; r++) {
+    const s = performance.now();
+    for (let i = 0; i < base.length; i++) await gen(decorate(base[i], r, i));
+    perRound.push(performance.now() - s);
+  }
+  await sql.end();
+  return median(perRound) / QUERIES;
+}
+
+async function main() {
+  await setupDb();
+
+  const distinct = await measure((text, round, index) => `${text} /*d${round}-${index}*/`);
+  const repeated = await measure((text) => text);
+
+  const metrics = {
+    schemaTables: EXTRA_TABLES,
+    queries: QUERIES,
+    rounds: ROUNDS,
+    msPerQueryDistinct: Number(distinct.toFixed(4)),
+    msPerQueryRepeated: Number(repeated.toFixed(4)),
+    nodeVersion: process.version,
+  };
+
+  const out = JSON.stringify(metrics, null, 2);
+  const dest = process.argv[2];
+  if (dest) fs.writeFileSync(dest, out);
+  console.log(out);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/generate/bench/compare.mjs
+++ b/packages/generate/bench/compare.mjs
@@ -1,0 +1,72 @@
+// Compares two bench runs (base vs PR), renders every ms* metric, gates on one.
+//   node compare.mjs <base.json> <pr.json> <gateMetric> [thresholdPct=25] [title]
+import fs from "node:fs";
+
+const [baseFile, prFile, gateKey, thresholdArg, title] = process.argv.slice(2);
+if (!baseFile || !prFile || !gateKey) {
+  console.error("Usage: compare.mjs <base.json> <pr.json> <gateMetric> [thresholdPct=25] [title]");
+  process.exit(1);
+}
+const threshold = thresholdArg === undefined ? 25 : Number(thresholdArg);
+if (!Number.isFinite(threshold) || threshold < 0) {
+  console.error(`Invalid threshold: ${thresholdArg}`);
+  process.exit(1);
+}
+
+function readMetrics(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    console.error(`Could not read benchmark metrics from ${file}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+const base = readMetrics(baseFile);
+const pr = readMetrics(prFile);
+
+const keys = Object.keys(base).filter(
+  (k) => k.startsWith("ms") && Number.isFinite(base[k]) && Number.isFinite(pr[k]),
+);
+if (!keys.includes(gateKey)) {
+  console.error(`Gate metric "${gateKey}" missing or non-numeric in the bench output`);
+  process.exit(1);
+}
+
+const pct = (k) => ((pr[k] - base[k]) / base[k]) * 100;
+const fmt = (d) => `${d >= 0 ? "+" : ""}${d.toFixed(1)}%`;
+const canGate = base[gateKey] > 0;
+const gateDelta = canGate ? pct(gateKey) : 0;
+const emoji = !canGate ? "⚪️" : gateDelta >= threshold ? "🔴" : gateDelta < -10 ? "🟢" : "⚪️";
+
+const rows = keys.map((k) => {
+  const delta = base[k] > 0 ? fmt(pct(k)) : "n/a";
+  return `| ${k}${k === gateKey ? " (gate)" : ""} | ${base[k]} | ${pr[k]} | ${delta} |`;
+});
+
+const verdict = !canGate
+  ? `\`${gateKey}\` baseline is 0; nothing to gate on.`
+  : gateDelta >= threshold
+    ? `⚠️ **\`${gateKey}\` ${fmt(gateDelta)} vs base** (threshold ${threshold}%). Same-runner comparison, so this is a real regression.`
+    : gateDelta < -10
+      ? `\`${gateKey}\` ${fmt(gateDelta)} vs base. 🎉`
+      : `\`${gateKey}\` ${fmt(gateDelta)} vs base — within noise.`;
+
+const summary = [
+  `### ${emoji} ${title ?? "performance"}`,
+  "",
+  "| metric | base | PR | Δ |",
+  "| --- | --- | --- | --- |",
+  ...rows,
+  "",
+  verdict,
+].join("\n");
+
+console.log(summary);
+const out = process.env.GITHUB_STEP_SUMMARY;
+if (out) fs.appendFileSync(out, summary + "\n");
+
+if (canGate && gateDelta >= threshold) {
+  console.error(`\nRegression ${fmt(gateDelta)} exceeds threshold ${threshold}%`);
+  process.exit(1);
+}

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -32,6 +32,7 @@
     "build": "unbuild",
     "dev": "unbuild --stub",
     "test": "vitest",
+    "bench": "tsx bench/bench.mts",
     "lint": "eslint src",
     "lint!": "eslint src --fix",
     "publint": "publint",

--- a/packages/generate/src/ast-get-sources.ts
+++ b/packages/generate/src/ast-get-sources.ts
@@ -64,26 +64,6 @@ export function getSources({
 }: SourcesOptions) {
   const nonNullableViewColumnsCache = new Map<string, Set<string> | undefined>();
 
-  const tableToSchema = new Map<string, string>();
-
-  const publicCols = pgColsBySchemaAndTableName.get("public");
-
-  if (publicCols) {
-    for (const tableName of publicCols.keys()) {
-      tableToSchema.set(tableName, "public");
-    }
-  }
-
-  for (const [schemaName, cols] of pgColsBySchemaAndTableName) {
-    if (schemaName === "public") break;
-
-    for (const tableName of cols.keys()) {
-      if (!tableToSchema.has(tableName)) {
-        tableToSchema.set(tableName, schemaName);
-      }
-    }
-  }
-
   function getColumnCTEs(ctes: LibPgQueryAST.Node[]): Map<string, SourcesResolver> {
     const map = new Map<string, SourcesResolver>();
 

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -86,7 +86,74 @@ type Cache = {
     columns: Map<string, Map<string, Map<string, string>>>;
   };
   functions: Map<string, FunctionsMap>;
+  results: Map<CacheKey, Map<string, CachedQueryResult>>;
 };
+
+type CachedQueryResult = Pick<GenerateResult, "output" | "unknownColumns" | "stmt">;
+
+const MAX_RESULT_CACHE_ENTRIES = 5_000;
+
+function stableStringify(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+  return `{${entries.join(",")}}`;
+}
+
+function getResultCacheForKey(cache: Cache, cacheKey: CacheKey): Map<string, CachedQueryResult> {
+  let map = cache.results.get(cacheKey);
+  if (map === undefined) {
+    map = new Map();
+    cache.results.set(cacheKey, map);
+  }
+  return map;
+}
+
+function getCachedResult(
+  cache: Map<string, CachedQueryResult>,
+  key: string,
+): CachedQueryResult | undefined {
+  const hit = cache.get(key);
+  if (hit !== undefined) {
+    cache.delete(key);
+    cache.set(key, hit); // bump recency
+  }
+  return hit;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value)) {
+      deepFreeze(child);
+    }
+  }
+  return value;
+}
+
+function setCachedResult(
+  cache: Map<string, CachedQueryResult>,
+  key: string,
+  value: CachedQueryResult,
+): void {
+  cache.delete(key); // bump recency
+  cache.set(key, deepFreeze(value));
+  if (cache.size > MAX_RESULT_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) {
+      cache.delete(oldest);
+    }
+  }
+}
 
 function createEmptyCache(): Cache {
   return {
@@ -96,6 +163,7 @@ function createEmptyCache(): Cache {
       columns: new Map(),
     },
     functions: new Map(),
+    results: new Map(),
   };
 }
 
@@ -104,12 +172,17 @@ export function createGenerator() {
 
   return {
     generate: (params: GenerateParams) => generate(params, cache),
-    dropCacheKey: (cacheKey: CacheKey) => cache.base.delete(cacheKey),
+    dropCacheKey: (cacheKey: CacheKey) => {
+      cache.base.delete(cacheKey);
+      cache.results.delete(cacheKey);
+      cache.functions.clear();
+    },
     clearCache: () => {
       cache.base.clear();
       cache.overrides.types.clear();
       cache.overrides.columns.clear();
       cache.functions.clear();
+      cache.results.clear();
     },
   };
 }
@@ -196,16 +269,44 @@ async function generate(
     },
   });
 
+  const resultKey = stableStringify([
+    params.fieldTransform ?? null,
+    params.overrides ?? null,
+    query.text,
+  ]);
+  const resultCache = cacheMetadata ? getResultCacheForKey(cache, cacheKey) : undefined;
+
+  const cached = resultCache !== undefined ? getCachedResult(resultCache, resultKey) : undefined;
+  if (cached !== undefined) {
+    return either.right({ ...cached, query });
+  }
+
+  const cacheResult = (value: CachedQueryResult): CachedQueryResult => {
+    if (resultCache !== undefined) {
+      setCachedResult(resultCache, resultKey, value);
+    }
+    return value;
+  };
+
   try {
-    const result = await sql.unsafe(query.text, [], { prepare: true }).describe();
-    const parsed = await parser.parse(query.text);
+    const [describeOutcome, parseOutcome] = await Promise.allSettled([
+      sql.unsafe(query.text, [], { prepare: true }).describe(),
+      parser.parse(query.text),
+    ]);
+    if (describeOutcome.status === "rejected") throw describeOutcome.reason;
+    if (parseOutcome.status === "rejected") throw parseOutcome.reason;
+    const result = describeOutcome.value;
+    const parsed = parseOutcome.value;
 
     if (isParsedInsertResult(parsed)) {
       validateInsertResult(parsed, pgColsBySchemaAndTableName, query);
     }
 
     if (result.columns === undefined || result.columns === null || result.columns.length === 0) {
-      return either.right({ output: null, unknownColumns: [], stmt: result, query: query });
+      return either.right({
+        ...cacheResult({ output: null, unknownColumns: [], stmt: result }),
+        query,
+      });
     }
 
     const duplicateCols = result.columns.filter((col, index) =>
@@ -289,11 +390,13 @@ async function generate(
     };
 
     return either.right({
-      output: getTypedColumnEntries({ context }),
-      unknownColumns: columns
-        .filter((x) => x.astDescribed === undefined)
-        .map((x) => x.described.name),
-      stmt: result,
+      ...cacheResult({
+        output: getTypedColumnEntries({ context }),
+        unknownColumns: columns
+          .filter((x) => x.astDescribed === undefined)
+          .map((x) => x.described.name),
+        stmt: result,
+      }),
       query: query,
     });
   } catch (e) {


### PR DESCRIPTION
Speeds up query type generation and adds performance monitoring.

## Performance (`@ts-safeql/generate`)
- Cache results per connection, so repeated queries (watch mode, CI, the same query reused across files) skip the Postgres describe and SQL parse.
- Drop a per-query schema scan in `getSources` whose cost grew with database size.
- Run the describe round-trip concurrently with SQL parsing.

## Benchmarks
- `generate()` and check-sql lint-rule benchmarks, run on the base and PR branches on the same runner (absolute timings vary ~3x across runners, so only the relative delta is trusted).
- CI gates the lint rule on its isolated overhead (lint with the rule on minus off) and generate on per-query cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated performance benchmarks and PR reporting for query generation and the SQL lint rule, including a PR comment summary and automatic base-vs-PR comparison.

* **Performance**
  * Improved query generation performance with per-query result caching and faster SQL analysis during generation.
  * Enhanced benchmarking to cover both repeated and distinct query scenarios, with gated regression detection.

* **Bug Fixes**
  * Fixed/streamlined schema resolution during source extraction.
  * Improved cache cleanup to keep benchmark and generation behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->