### PR TITLE
perf(generate): cache query results and drop dead per-query work

### DIFF
--- a/packages/generate/src/ast-get-sources.ts
+++ b/packages/generate/src/ast-get-sources.ts
@@ -64,26 +64,6 @@ export function getSources({
 }: SourcesOptions) {
   const nonNullableViewColumnsCache = new Map<string, Set<string> | undefined>();
 
-  const tableToSchema = new Map<string, string>();
-
-  const publicCols = pgColsBySchemaAndTableName.get("public");
-
-  if (publicCols) {
-    for (const tableName of publicCols.keys()) {
-      tableToSchema.set(tableName, "public");
-    }
-  }
-
-  for (const [schemaName, cols] of pgColsBySchemaAndTableName) {
-    if (schemaName === "public") break;
-
-    for (const tableName of cols.keys()) {
-      if (!tableToSchema.has(tableName)) {
-        tableToSchema.set(tableName, schemaName);
-      }
-    }
-  }
-
   function getColumnCTEs(ctes: LibPgQueryAST.Node[]): Map<string, SourcesResolver> {
     const map = new Map<string, SourcesResolver>();
 

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -283,8 +283,17 @@ async function generate(
   };
 
   try {
-    const result = await sql.unsafe(query.text, [], { prepare: true }).describe();
-    const parsed = await parser.parse(query.text);
+    // describe (DB round-trip) and parse (WASM CPU) both depend only on the query
+    // text, so run them together — the parse hides under the round-trip. The
+    // Postgres error is checked first so it stays authoritative over a parse error.
+    const [describeOutcome, parseOutcome] = await Promise.allSettled([
+      sql.unsafe(query.text, [], { prepare: true }).describe(),
+      parser.parse(query.text),
+    ]);
+    if (describeOutcome.status === "rejected") throw describeOutcome.reason;
+    if (parseOutcome.status === "rejected") throw parseOutcome.reason;
+    const result = describeOutcome.value;
+    const parsed = parseOutcome.value;
 
     if (isParsedInsertResult(parsed)) {
       validateInsertResult(parsed, pgColsBySchemaAndTableName, query);

--- a/packages/generate/src/generate.ts
+++ b/packages/generate/src/generate.ts
@@ -86,7 +86,68 @@ type Cache = {
     columns: Map<string, Map<string, Map<string, string>>>;
   };
   functions: Map<string, FunctionsMap>;
+  results: Map<CacheKey, Map<string, CachedQueryResult>>;
 };
+
+type CachedQueryResult = Pick<GenerateResult, "output" | "unknownColumns" | "stmt">;
+
+// Caps the cache so a long-lived worker (editor/watch) can't grow unbounded as
+// query texts change. Map order is insertion order, so eviction is LRU.
+const MAX_RESULT_CACHE_ENTRIES = 5_000;
+
+// Order-independent, so overrides built with different key orders still map to
+// the same cache key instead of spuriously missing.
+function stableStringify(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+  return `{${entries.join(",")}}`;
+}
+
+function getResultCacheForKey(cache: Cache, cacheKey: CacheKey): Map<string, CachedQueryResult> {
+  let map = cache.results.get(cacheKey);
+  if (map === undefined) {
+    map = new Map();
+    cache.results.set(cacheKey, map);
+  }
+  return map;
+}
+
+function getCachedResult(
+  cache: Map<string, CachedQueryResult>,
+  key: string,
+): CachedQueryResult | undefined {
+  const hit = cache.get(key);
+  if (hit !== undefined) {
+    cache.delete(key);
+    cache.set(key, hit);
+  }
+  return hit;
+}
+
+function setCachedResult(
+  cache: Map<string, CachedQueryResult>,
+  key: string,
+  value: CachedQueryResult,
+): void {
+  cache.delete(key); // re-insert so an existing key moves to the most-recent slot
+  cache.set(key, value);
+  if (cache.size > MAX_RESULT_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) {
+      cache.delete(oldest);
+    }
+  }
+}
 
 function createEmptyCache(): Cache {
   return {
@@ -96,6 +157,7 @@ function createEmptyCache(): Cache {
       columns: new Map(),
     },
     functions: new Map(),
+    results: new Map(),
   };
 }
 
@@ -104,12 +166,16 @@ export function createGenerator() {
 
   return {
     generate: (params: GenerateParams) => generate(params, cache),
-    dropCacheKey: (cacheKey: CacheKey) => cache.base.delete(cacheKey),
+    dropCacheKey: (cacheKey: CacheKey) => {
+      cache.base.delete(cacheKey);
+      cache.results.delete(cacheKey);
+    },
     clearCache: () => {
       cache.base.clear();
       cache.overrides.types.clear();
       cache.overrides.columns.clear();
       cache.functions.clear();
+      cache.results.clear();
     },
   };
 }
@@ -196,6 +262,26 @@ async function generate(
     },
   });
 
+  const resultKey = stableStringify([
+    params.fieldTransform ?? null,
+    params.overrides ?? null,
+    query.text,
+  ]);
+  const resultCache = cacheMetadata ? getResultCacheForKey(cache, cacheKey) : undefined;
+
+  const cached = resultCache !== undefined ? getCachedResult(resultCache, resultKey) : undefined;
+  if (cached !== undefined) {
+    // Sourcemaps are per-occurrence, so re-attach the live query.
+    return either.right({ ...cached, query });
+  }
+
+  const cacheResult = (value: CachedQueryResult): CachedQueryResult => {
+    if (resultCache !== undefined) {
+      setCachedResult(resultCache, resultKey, value);
+    }
+    return value;
+  };
+
   try {
     const result = await sql.unsafe(query.text, [], { prepare: true }).describe();
     const parsed = await parser.parse(query.text);
@@ -205,7 +291,7 @@ async function generate(
     }
 
     if (result.columns === undefined || result.columns === null || result.columns.length === 0) {
-      return either.right({ output: null, unknownColumns: [], stmt: result, query: query });
+      return either.right({ ...cacheResult({ output: null, unknownColumns: [], stmt: result }), query });
     }
 
     const duplicateCols = result.columns.filter((col, index) =>
@@ -289,11 +375,13 @@ async function generate(
     };
 
     return either.right({
-      output: getTypedColumnEntries({ context }),
-      unknownColumns: columns
-        .filter((x) => x.astDescribed === undefined)
-        .map((x) => x.described.name),
-      stmt: result,
+      ...cacheResult({
+        output: getTypedColumnEntries({ context }),
+        unknownColumns: columns
+          .filter((x) => x.astDescribed === undefined)
+          .map((x) => x.described.name),
+        stmt: result,
+      }),
       query: query,
     });
   } catch (e) {


### PR DESCRIPTION
Stacked on #501.

- Cache query results per connection (LRU-bounded; cleared on migration change), so repeated query texts skip the describe + parse.
- Drop a dead per-query `tableToSchema` loop in `getSources` that scaled with database size.

Changeset held until the perf job's numbers are in.
